### PR TITLE
Fix installation of NPM

### DIFF
--- a/provisioning/ansible/roles/web/tasks/main.yml
+++ b/provisioning/ansible/roles/web/tasks/main.yml
@@ -64,7 +64,7 @@
   yum: name=nodejs state=present
 
 - name: Install NPM
-  command: wget -O- https://www.npmjs.org/install.sh | sudo sh creates=/usr/bin/npm
+  shell: wget -O- https://www.npmjs.org/install.sh | sudo sh creates=/usr/bin/npm
 
 - name: Install LESS compiler
   npm: name=less global=yes state=present


### PR DESCRIPTION
The command module does not support "advanced" shell operations like piping, this breaks the installation of NPM. The shell module does support this.
