### PR TITLE
Install LESS compiler version 1.x

### DIFF
--- a/provisioning/ansible/roles/web/tasks/main.yml
+++ b/provisioning/ansible/roles/web/tasks/main.yml
@@ -79,4 +79,4 @@
   shell: wget -O- https://www.npmjs.org/install.sh | sudo sh creates=/usr/bin/npm
 
 - name: Install LESS compiler
-  npm: name=less global=yes state=present
+  npm: name=less version=1.x global=yes state=present


### PR DESCRIPTION
LESS 2.0.0 was released two weeks ago, breaking the Assetic build. Reverting to 1.x (1.7.5) solves this problem.

```
[exception] 500 | Internal Server Error | Assetic\Exception\FilterException
[message] An error occurred while running:
&#039;/usr/bin/node&#039; &#039;/tmp/assetic_lessdfZS6y&#039;

Error Output:

/usr/lib/node_modules/less/lib/less/parser/parser.js:108
            imports.contents[fileInfo.filename] = str;
                   ^
TypeError: Cannot read property &#039;contents&#039; of undefined
    at Object.Parser.parse (/usr/lib/node_modules/less/lib/less/parser/parser.js:108:20)
    at Object.&lt;anonymous&gt; (/tmp/assetic_lessdfZS6y:4:174)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```
