### PR TITLE
Introduce Tiqr to the platform

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,8 @@ required_directories = [
     "Stepup-Gateway",
     "Stepup-Middleware",
     "Stepup-RA",
-    "Stepup-SelfService"
+    "Stepup-SelfService",
+    "Stepup-tiqr"
 ]
 
 Vagrant.configure("2") do |config|
@@ -53,11 +54,13 @@ Vagrant.configure("2") do |config|
         apps.vm.synced_folder "../Stepup-SelfService", "/var/www/ss-dev.stepup.coin.surf.net"
         apps.vm.synced_folder "../Stepup-RA",          "/var/www/ra-dev.stepup.coin.surf.net"
         apps.vm.synced_folder "../simplesamlphp",      "/var/www/idp-dev.stepup.coin.surf.net"
+        apps.vm.synced_folder "../Stepup-tiqr",      "/var/www/tiqr-dev.stepup.coin.surf.net"
         apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=middleware,gid=middleware   var_www_mw-dev.stepup.coin.surf.net /var/www/mw-dev.stepup.coin.surf.net"
         apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=gateway,gid=gateway         var_www_gw-dev.stepup.coin.surf.net /var/www/gw-dev.stepup.coin.surf.net"
         apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=selfservice,gid=selfservice var_www_ss-dev.stepup.coin.surf.net /var/www/ss-dev.stepup.coin.surf.net"
         apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=ra,gid=ra                   var_www_ra-dev.stepup.coin.surf.net /var/www/ra-dev.stepup.coin.surf.net"
         apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=simplesaml,gid=simplesaml   var_www_idp-dev.stepup.coin.surf.net /var/www/idp-dev.stepup.coin.surf.net"
+        apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=tiqr,gid=tiqr   var_www_tiqr-dev.stepup.coin.surf.net /var/www/tiqr-dev.stepup.coin.surf.net"
         apps.vm.provision :shell, run: "always", inline: "pkill mailcatcher || true"
         apps.vm.provision :shell, run: "always", inline: "/usr/local/bin/mailcatcher --ip=0.0.0.0"
     end

--- a/ansible/roles/web/tasks/main.yml
+++ b/ansible/roles/web/tasks/main.yml
@@ -54,12 +54,13 @@
 - include: vhost.yml vhost_name=ss-dev tpl=default vhost_local_port=9002 user=selfservice port=443
 - include: vhost.yml vhost_name=ra-dev tpl=default vhost_local_port=9003 user=ra port=443
 - include: vhost.yml vhost_name=idp-dev tpl=simplesaml vhost_local_port=9004 user=simplesaml port=443
+- include: vhost.yml vhost_name=tiqr-dev tpl=tiqr vhost_local_port=9005 user=tiqr port=443
   notify:
    - restart nginx
    - restart php-fpm
 
 - name: Add nginx to user groups
-  user: name=nginx groups=nginx,middleware,gateway,selfservice,ra createhome=no state=present
+  user: name=nginx groups=nginx,middleware,gateway,selfservice,ra,tiqr createhome=no state=present
 
 - name: Remove default PHP-FPM vhost 'www'
   file: path=/etc/php-fpm.d/www.conf state=absent

--- a/ansible/roles/web/templates/nginx-vhost-tiqr.conf.j2
+++ b/ansible/roles/web/templates/nginx-vhost-tiqr.conf.j2
@@ -1,0 +1,30 @@
+server {
+    listen 80;
+    server_name {{ vhost_name }}.{{ app_domain }};
+
+    rewrite ^/(.*) https://{{ vhost_name }}.{{ app_domain }}/$1 permanent;
+}
+
+server {
+    listen 443 ssl;
+
+    server_name {{ vhost_name }}.{{ app_domain }};
+
+    root /var/www/{{ vhost_name }}.{{ app_domain }}/www;
+
+    location / {
+        # try to serve file directly, fallback to index.php
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ ^/(.+\.php)(/|$) {
+        fastcgi_pass unix:/var/run/php-fpm/{{ vhost_name }}.socket;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    error_log /var/log/nginx/{{ vhost_name }}_error.log;
+    access_log /var/log/nginx/{{ vhost_name }}_access.log;
+}


### PR DESCRIPTION
In order to comfortably develop for Tiqr in Stepup's ecosystem, it should be embedded in Stepup's current development environment. 

Work still has to be done to correctly configure nginx for Tiqr and setup Tiqr as a working Second Factor. Then, documentation on how to setup Tiqr and how to develop and test it should be added.