### PR TITLE
Use NFS instead of vboxsf for all shared folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,18 +46,16 @@ Vagrant.configure("2") do |config|
             apps.vm.provision :shell, inline: "env PLAYBOOK=ansible/stepup.yml ansible/windows.sh"
         end
 
-        # Mount shared folders after provisioning
-        # https://github.com/mitchellh/vagrant/issues/936#issuecomment-7179034
-        apps.vm.synced_folder "../Stepup-Middleware",  "/var/www/mw-dev.stepup.coin.surf.net"
-        apps.vm.synced_folder "../Stepup-Gateway",     "/var/www/gw-dev.stepup.coin.surf.net"
-        apps.vm.synced_folder "../Stepup-SelfService", "/var/www/ss-dev.stepup.coin.surf.net"
-        apps.vm.synced_folder "../Stepup-RA",          "/var/www/ra-dev.stepup.coin.surf.net"
-        apps.vm.synced_folder "../simplesamlphp",      "/var/www/idp-dev.stepup.coin.surf.net"
-        apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=middleware,gid=middleware   var_www_mw-dev.stepup.coin.surf.net /var/www/mw-dev.stepup.coin.surf.net"
-        apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=gateway,gid=gateway         var_www_gw-dev.stepup.coin.surf.net /var/www/gw-dev.stepup.coin.surf.net"
-        apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=selfservice,gid=selfservice var_www_ss-dev.stepup.coin.surf.net /var/www/ss-dev.stepup.coin.surf.net"
-        apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=ra,gid=ra                   var_www_ra-dev.stepup.coin.surf.net /var/www/ra-dev.stepup.coin.surf.net"
-        apps.vm.provision :shell, run: "always", inline: "mount -t vboxsf -o uid=simplesaml,gid=simplesaml   var_www_idp-dev.stepup.coin.surf.net /var/www/idp-dev.stepup.coin.surf.net"
+        # The synced folders will be mounted with uid 1000, which,
+        # after provisioning, will be selfservice. This should not be
+        # a problem because on the VM, every user can read other users
+        # files.
+        apps.vm.synced_folder "../Stepup-Middleware",  "/var/www/mw-dev.stepup.coin.surf.net", type: "nfs"
+        apps.vm.synced_folder "../Stepup-Gateway",     "/var/www/gw-dev.stepup.coin.surf.net", type: "nfs"
+        apps.vm.synced_folder "../Stepup-SelfService", "/var/www/ss-dev.stepup.coin.surf.net", type: "nfs"
+        apps.vm.synced_folder "../Stepup-RA",          "/var/www/ra-dev.stepup.coin.surf.net", type: "nfs"
+        apps.vm.synced_folder "../simplesamlphp",      "/var/www/idp-dev.stepup.coin.surf.net", type: "nfs"
+
         apps.vm.provision :shell, run: "always", inline: "pkill mailcatcher || true"
         apps.vm.provision :shell, run: "always", inline: "/usr/local/bin/mailcatcher --ip=0.0.0.0"
     end


### PR DESCRIPTION
This should improve performance of the applications greatly. The issue
where the folders could not be mounted because the users (middleware,
gateway, etc) were not yet provisioned should not be an issue for NFS
since we provide read/write access for all users.