### PR TITLE
Add php-gd to the list of PHP packages

### DIFF
--- a/ansible/stepup.yml
+++ b/ansible/stepup.yml
@@ -6,6 +6,7 @@
     app_domain: stepup.coin.surf.net
     php_packages:
       - php-bcmath
+      - php-gd
       - php-intl
       - php-mbstring
       - php-mcrypt


### PR DESCRIPTION
GD is required for embedding logos in generated PDF files. Stepup can
be deployed without this dependency; a red cross will be displayed in
the PDF instead of the logo.

See: https://www.pivotaltracker.com/n/projects/1163646/stories/153358379/