### PR TITLE
Fix SAML private key generation error

### DIFF
--- a/scripts/gen_selfsigned_cert.sh
+++ b/scripts/gen_selfsigned_cert.sh
@@ -63,7 +63,7 @@ if [ $? -ne "0" ]; then
 fi
 
 # Generate RSA private key with RSA_MODULUS_SIZE_BITS bit modulus
-${OPENSSL} genrsa -out ${tmpdir}/private_key.pem ${RSA_MODULUS_SIZE_BITS} -nodes
+${OPENSSL} genrsa -out ${tmpdir}/private_key.pem ${RSA_MODULUS_SIZE_BITS}
 if [ $? -ne "0" ]; then
     error_exit "Error generating key"
 fi


### PR DESCRIPTION
The Stepup-VM init-env.sh script currently errors with the message
"Extra arguments given.".

The "no des" option is only valid for the openssl-req command and not
valid in the context of genrsa.