### PR TITLE
Use setfacl to grant permissions to source directories

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -32,12 +32,12 @@
   when: not develop | default(false)
 
 - block:
-    - name: Set file ACL on shared source directory
+    - name: DEVELOP - Set file ACL on shared source directory
       acl: name={{ component_dir_name }} entity={{item}} etype=user permissions=rwx default=no recursive=yes state=present
       with_items:
         - "{{ component_name }}"
 
-    - name: Set default file ACL on shared source directory
+    - name: DEVELOP - Set default file ACL on shared source directory
       acl: name={{ component_dir_name }} entity={{item}} etype=user permissions=rwx default=yes recursive=yes state=present
       with_items:
         - "{{ component_name }}"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -32,6 +32,16 @@
   when: not develop | default(false)
 
 - block:
+    - name: Set file ACL on shared source directory
+      acl: name={{ component_dir_name }} entity={{item}} etype=user permissions=rwx default=no recursive=yes state=present
+      with_items:
+        - "{{ component_name }}"
+
+    - name: Set default file ACL on shared source directory
+      acl: name={{ component_dir_name }} entity={{item}} etype=user permissions=rwx default=yes recursive=yes state=present
+      with_items:
+        - "{{ component_name }}"
+
     - name: DEVELOP - Composer install
       shell: export COMPOSER_CACHE_DIR=/vagrant/composer_cache && /usr/local/bin/composer install --no-interaction --working-dir={{ component_dir_name }}
 

--- a/roles/stepup-gateway/tasks/main.yml
+++ b/roles/stepup-gateway/tasks/main.yml
@@ -2,7 +2,7 @@
 
 
 - name: Put parameters.yml and samlstepupproviders(_parameters).yml
-  template: src={{ item }}.j2 dest={{ component_dir_name }}/app/config/{{ item }} mode=640
+  template: src={{ item }}.j2 dest={{ component_dir_name }}/app/config/{{ item }} mode={{ component_mode_640 }} group={{ component_name }}
   with_items:
   - parameters.yml
   - samlstepupproviders.yml

--- a/roles/stepup-gateway/tasks/main.yml
+++ b/roles/stepup-gateway/tasks/main.yml
@@ -2,7 +2,7 @@
 
 
 - name: Put parameters.yml and samlstepupproviders(_parameters).yml
-  template: src={{ item }}.j2 dest={{ component_dir_name }}/app/config/{{ item }} mode=640 group={{ component_name }}
+  template: src={{ item }}.j2 dest={{ component_dir_name }}/app/config/{{ item }} mode=640
   with_items:
   - parameters.yml
   - samlstepupproviders.yml


### PR DESCRIPTION
In order for the provision to work with NFS on Linux I propose two changes:

 - don't change the group of files inside /src, NFS does not support this
 - use setfacl to grant the component users (gateway, selfservice, ...) rwx access to their respective directories in /src

@pmeulen the roles/*/tasks/main.yml files might need some more work. Lots of task contain this option:

    group={{ component_group }} 

But component_group is always empty so ansible doesn't try to change the group, which is why the tasks didn't fail on NFS. The line in gateway main.yml is different:

    group={{ component_name }}

And since component_name is not empty, it fails on NFS.