### PR TITLE
Change 'when' statements to avoid warnings in 2.3+.

### DIFF
--- a/roles/stepup-gateway/tasks/main.yml
+++ b/roles/stepup-gateway/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Untar component
   unarchive: copy=yes src={{ component_tarball_name }} dest={{ component_dir_name }} group={{ component_name }}
-  when: ( {{ component_unarchive | default(1) }} == 1)
+  when: component_unarchive | bool | default(true)
 
 - name: Remove group and world write
   file: dest={{ component_dir_name }} group={{ component_name }} recurse=yes mode="g-w,o-w"

--- a/roles/stepup-keyserver/tasks/main.yml
+++ b/roles/stepup-keyserver/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Untar component
   unarchive: copy=yes src={{ component_tarball_name }} dest={{ component_dir_name }} group={{ component_name }}
-  when: ( {{ component_unarchive | default(1) }} == 1)
+  when: component_unarchive | bool | default(true)
 
 - name: Remove group and world write
   file: dest={{ component_dir_name }} group={{ component_name }} recurse=yes mode="g-w,o-w"

--- a/roles/stepup-middleware/tasks/main.yml
+++ b/roles/stepup-middleware/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Untar component
   unarchive: copy=yes src={{ component_tarball_name }} dest={{ component_dir_name }} group={{ component_name }}
-  when: ( {{ component_unarchive | default(1) }} == 1)
+  when: component_unarchive | bool | default(true)
 
 - name: Remove group and world write
   file: dest={{ component_dir_name }} group={{ component_name }} recurse=yes mode="g-w,o-w"

--- a/roles/stepup-ra/tasks/main.yml
+++ b/roles/stepup-ra/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Untar component
   unarchive: copy=yes src={{ component_tarball_name }} dest={{ component_dir_name }} group={{ component_name }}
-  when: ( {{ component_unarchive | default(1) }} == 1)
+  when: component_unarchive | bool | default(true)
 
 - name: Remove group and world write
   file: dest={{ component_dir_name }} group={{ component_name }} recurse=yes mode="g-w,o-w"

--- a/roles/stepup-selfservice/tasks/main.yml
+++ b/roles/stepup-selfservice/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Untar component
   unarchive: copy=yes src={{ component_tarball_name }} dest={{ component_dir_name }} group={{ component_name }}
-  when: ( {{ component_unarchive | default(1) }} == 1)
+  when: component_unarchive | bool | default(true)
 
 - name: Remove group and world write
   file: dest={{ component_dir_name }} group={{ component_name }} recurse=yes mode="g-w,o-w"

--- a/roles/stepup-tiqr/tasks/main.yml
+++ b/roles/stepup-tiqr/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Untar component
   unarchive: copy=yes src={{ component_tarball_name }} dest={{ component_dir_name }} group={{ component_name }}
-  when: ( {{ component_unarchive | default(1) }} == 1)
+  when: component_unarchive | bool | default(true)
 
 - name: Remove group and world write
   file: dest={{ component_dir_name }} group={{ component_name }} recurse=yes mode="g-w,o-w"


### PR DESCRIPTION
 'when' statements without jinja2 delimiters.