### PR TITLE
Make sure a single node Galera cluster always starts up as a new cluster

### DIFF
--- a/roles/db/templates/server.cnf.j2
+++ b/roles/db/templates/server.cnf.j2
@@ -40,7 +40,7 @@ innodb_file_per_table
 innodb_flush_log_at_trx_commit=2
 
 wsrep_provider=/usr/lib64/galera/libgalera_smm.so
-wsrep_cluster_address="gcomm://{% for host in groups['dbcluster'] %}{{ hostvars[host]['backend_ipv4'] }}{% if not loop.last %},{% endif %}{% endfor %}"
+wsrep_cluster_address="gcomm://{% if groups['dbcluster']|length > 1 %}{% for host in groups['dbcluster'] %}{{ hostvars[host]['backend_ipv4'] }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}"
 wsrep_cluster_name='{{ mariadb_cluster_name }}'
 wsrep_node_address='{{ backend_ipv4 }}:4567'
 wsrep_node_name='{{ inventory_hostname }}'


### PR DESCRIPTION
When there is only one database server, leave the `gcom://` empty, to force starting up alone, thus initialising a new cluster.
See http://galeracluster.com/documentation-webpages/mysqlwsrepoptions.html#wsrep-cluster-address.
Fixes https://github.com/OpenConext/Stepup-Deploy/issues/61