### PR TITLE
Update database init script

### DIFF
--- a/roles/stepup-tiqr/templates/01-tiqr-db_init.sh.j2
+++ b/roles/stepup-tiqr/templates/01-tiqr-db_init.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mysql -v -u {{ database_tiqr_deploy_user }} -p{{ database_tiqr_deploy_password | vault(vault_keydir) }} -h {{ database_lb_address }} {{ database_tiqr_name }} < /opt/www/{{ tiqr_vhost_name }}/db/mysql-create-tables.sql
+mysql -v -u {{ database_tiqr_deploy_user }} -p{{ database_tiqr_deploy_password | vault(vault_keydir) }} -h {{ database_lb_address }} {{ database_tiqr_name }} < /opt/www/{{ tiqr_vhost_name }}/app/Resources/db/mysql-create-tables.sql
 res=$?
 if [ "$res" -gt 0 ]; then
     echo "mysql failed"


### PR DESCRIPTION
As of revision 73c5f44 of Stepup-tiqr (PR#30) the database init script
was moved to the `/app/Resources/db/` folder

See https://www.pivotaltracker.com/story/show/157279728