### PR TITLE
Allow setting of Symfony test env with a cookie

### DIFF
--- a/roles/app/templates/nginx-vhost.conf.j2
+++ b/roles/app/templates/nginx-vhost.conf.j2
@@ -62,6 +62,13 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param HTTPS on;
         fastcgi_param SYMFONY_ENV prod;
+
+        # If the testcookie is set, enable the test env, do not mistake SYMFONY_ENV with the APP_DEV variable being set.
+        set $symfony_environment dev;
+        if ($http_cookie ~* "testcookie" ) {
+            set $symfony_environment test;
+        }
+        fastcgi_param APP_DEV $symfony_environment;
     }
     {% else %}
     {# Producation config for stepup components #}

--- a/roles/app/templates/php-fpm-pool.conf.j2
+++ b/roles/app/templates/php-fpm-pool.conf.j2
@@ -198,6 +198,9 @@ slowlog = /var/log/php-fpm/www-slow.log
 ;env[TMPDIR] = /tmp
 ;env[TEMP] = /tmp
 
+; See the nginx-vhost.conf.j2 for the origin of this variable
+env[APP_DEV] = $APP_DEV
+
 ; Additional php.ini defines, specific to this pool of workers. These settings
 ; overwrite the values previously defined in the php.ini. The directives are the
 ; same as the PHP SAPI:


### PR DESCRIPTION
The appropriate Symfony env is now set on the SERVER superglobal under
the APP_DEV key. This value can be used to set the application env.

The main intent is to be able to manipulate the enviroment to set it in
test mode when running behat tests.

See: https://github.com/OpenConext/Stepup-Gateway/pull/164
See: https://www.pivotaltracker.com/story/show/156570267