### PR TITLE
Disallow opening PHP files outside of front controllers

### DIFF
--- a/roles/app/templates/nginx-vhost.conf.j2
+++ b/roles/app/templates/nginx-vhost.conf.j2
@@ -70,6 +70,10 @@ server {
         }
         fastcgi_param APP_DEV $symfony_environment;
     }
+    {# Finally, disallow opening php files outside of app_dev.php #}
+    location ~* \.php$ {
+        return 404;
+    }
     {% else %}
     {# Producation config for stepup components #}
     location / {
@@ -86,6 +90,10 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param HTTPS on;
         fastcgi_param SYMFONY_ENV prod;
+    }
+    {# Finally, disallow opening php files outside of app.php #}
+    location ~* \.php$ {
+        return 404;
     }
     {% endif %}
 {% endif %}


### PR DESCRIPTION
Other files than the Symfony front controllers are not required to be
accessed directly. This update of the NGINX vhost configuration for the
stepup apps ensures these other files cannot be downloaded.

See: https://www.pivotaltracker.com/story/show/158356638