### PR TITLE
Compatible with python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,17 @@ Using the [`create_new_environment.sh`](scripts/create_new_environment.sh) scrip
 
 The template contains an [`environment.conf`](environments/template/environment.conf) file that specifies the secrets to create. The first time you run the create_new_environment.sh script it is copied to the new environment and you get the change to edit/update this file. Take this chance to update this file to match your configuration, likely places to update are marked with "TODO:". You can also copy the `environments/template` directory to a new location to make your changes there (use the --template option). The environment can be used as-is to deploy to VMs created with the scripts in [Stepup-VM](https://github.com/SURFnet/Stepup-VM).
 
-Requirements for running the script:
-- *python* 2.7 (the scripts and playbooks are not compatible with python 3), ensure `python` points to a python 2.7.
+Requirements for running the script with python 2.7:
+- *python* 2.7
 - *openssl*
 - *python-keyczar*. You can use `pip install python-keyczar` to install this tool. This makes `keyczart` command available.
+
+Requirements for running the script with python3:
+- *python* 3
+- *openssl*
+- *python3-keyczar*. You can use `pip install python3-keyczar` to install this tool. This makes `keyczart` command available.
+
+On the mac `pip install python3-keyczar` works. However it might not work on centos. See https://github.com/google/keyczar/issues/125.
 
 Use `create_new_environment.sh <new_environment_directory> --template <template_environment_directory>` to create a new environment. The script will generate passwords, secrets, SAML signing certificates and SSL/TLS server certificates for use with HTTPS for the environment. All passwords, (private) keys and secrets are encrypted with a keyczar key that is specific for the environment. To issue the server certificates a self-signed CA is created using openssl.
 

--- a/filter_plugins/custom_plugins.py
+++ b/filter_plugins/custom_plugins.py
@@ -7,6 +7,7 @@
 # sha256: return hex encoded SHA-256 hash of string
 # depem: Strip PEM headers and remove all whitespace from string
 
+# Compatible with python2 and python3, but for python2 use python-keyczar and for python3 use python3-keyczar
 def vault(encrypted, keydir):
   #keydir = "~/.stepup-ansible-keystore"
   method = """
@@ -19,14 +20,15 @@ crypter = keyczar.Crypter.Read(expanded_keydir)
 sys.stdout.write(crypter.Decrypt("%s"))
   """ % (keydir, encrypted)
   from subprocess import check_output
-  return check_output(["python", "-c", method])
+  return check_output(["python", "-c", method], universal_newlines=True)
 
 
+# Compatible with python2 and python3
 def sha256s(data):
   import hashlib
-  return hashlib.sha256(data).hexdigest()
+  return hashlib.sha256(data.encode('utf-8')).hexdigest()
 
-
+# Compatible with python2 and python3
 def depem(string):
   import re
   return re.sub(r'\s+|(-----(BEGIN|END).*-----)', '', string)
@@ -37,8 +39,6 @@ class FilterModule(object):
   def filters(self):
     return {
       'vault': vault,
-
       'sha256': sha256s,
-
       'depem': depem,
     }

--- a/scripts/encrypt-file.sh
+++ b/scripts/encrypt-file.sh
@@ -15,9 +15,6 @@
 # limitations under the License.
 
 import sys
-if sys.version_info[0] > 2:
-    raise Exception("This script requires python 2")
-
 import os.path
 from optparse import OptionParser
 try:

--- a/scripts/encrypt.sh
+++ b/scripts/encrypt.sh
@@ -15,9 +15,6 @@
 # limitations under the License.
 
 import sys
-if sys.version_info[0] > 2:
-    raise Exception("This script requires python 2.")
-
 import os.path
 import getpass
 from optparse import OptionParser


### PR DESCRIPTION
Made custom_plugins compatible with python3 and updated the
documentation to use python3-keyczar for python3 environments.
Removed the version check from the encrypt scripts.