### PR TITLE
Fix behat test ra institution configuration

### DIFF
--- a/tests/behat/features/ra.feature
+++ b/tests/behat/features/ra.feature
@@ -8,6 +8,7 @@ Feature: A RAA manages tokens tokens registered in the selfservice portal
       And institution "institution-a.example.com" can "use_ra" from institution "institution-a.example.com"
       And institution "institution-a.example.com" can "use_ra" from institution "institution-d.example.com"
       And institution "institution-a.example.com" can "select_raa" from institution "institution-a.example.com"
+      And institution "institution-d.example.com" can "use_ra" from institution "institution-a.example.com"
       And the user "urn:collab:person:institution-a.example.com:jane-a-ra" has a vetted "yubikey"
       And the user "urn:collab:person:institution-a.example.com:jane-a-ra" has the role "ra" for institution "institution-a.example.com"
       And a user "Joe Satriani" identified by "urn:collab:person:institution-d.example.com:joe-d1" from institution "institution-d.example.com"


### PR DESCRIPTION
The ra tests failed becuase there was no valid ra institution
pushed to actt on behalf of.