### PR TITLE
Add tests to validate role authorization for RA routes

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -100,7 +100,18 @@ class FeatureContext implements Context
      */
     public function aUserIdentifiedByWithAVettedTokenAndTheRole($commonName, $nameId, $institution)
     {
-        $userId = (string)Uuid::uuid4();
+        $uuid = (string)Uuid::uuid4();
+
+        return $this->aUserIdentifiedByWithAVettedTokenAndTheRoleWithUuid($commonName, $nameId, $institution, $uuid);
+    }
+
+
+    /**
+     * @Given /^a user "([^"]*)" identified by "([^"]*)" from institution "([^"]*)" with UUID "([^"]*)"$/
+     */
+    public function aUserIdentifiedByWithAVettedTokenAndTheRoleWithUuid($commonName, $nameId, $institution, $uuid)
+    {
+        $userId = (string)$uuid;
 
         $identity = Identity::from($userId, $nameId, $commonName, $institution, []);
         $this->identityStore[$nameId] = $identity;
@@ -108,7 +119,6 @@ class FeatureContext implements Context
         $this->setPayload($this->payloadFactory->build('Identity:CreateIdentity', $identity));
         $this->connectToApi('ss', 'secret');
         $this->apiContext->iRequest('POST', '/command');
-
     }
 
     /**

--- a/tests/behat/features/bootstrap/RaContext.php
+++ b/tests/behat/features/bootstrap/RaContext.php
@@ -102,6 +102,18 @@ class RaContext implements Context
         $this->minkContext->assertPageContainsText('Token activation');
     }
 
+    /**
+     * @Given /^I visit the "([^"]*)" page in the RA environment$/
+     */
+    public function iVisitAPageinTheRaEnvironment($uri)
+    {
+        // The ra session is used to vet the token
+        $this->minkContext->getMink()->setDefaultSessionName(FeatureContext::SESSION_RA);
+
+        // We visit the RA location url
+        $this->minkContext->visit($this->raUrl.'/'.$uri);
+    }
+
     public function findsTokenForActivation()
     {
         // The activation token was previously set on the SP context, and can be retrieved here.

--- a/tests/behat/features/ra_grants.feature
+++ b/tests/behat/features/ra_grants.feature
@@ -1,0 +1,181 @@
+Feature: A RA(A) should only have access to certain pages
+
+  Scenario: Provision an institution and a user to promote later on by an authorized institution
+    Given institution "stepup.example.com" can "select_raa" from institution "stepup.example.com"
+    And institution "institution-a.example.com" can "use_ra" from institution "stepup.example.com"
+    And institution "institution-b.example.com" can "use_raa" from institution "stepup.example.com"
+    And institution "institution-d.example.com" can "select_raa" from institution "institution-d.example.com"
+    And institution "institution-d.example.com" can "use_raa" from institution "institution-d.example.com"
+    And a user "RA institution A" identified by "urn:collab:person:stepup.example.com:joe--ra" from institution "stepup.example.com" with UUID "00000000-0000-0000-0000-000000000001"
+    And a user "RAA institution B" identified by "urn:collab:person:stepup.example.com:joe--raa" from institution "stepup.example.com" with UUID "00000000-0000-0000-0000-000000000002"
+    And a user "RAA institution D" identified by "urn:collab:person:institution-d.example.com:joe-d-raa" from institution "institution-d.example.com" with UUID "00000000-0000-0000-0000-000000000003"
+    And a user "RA(A) candidate" identified by "urn:collab:person:institution-d.example.com:joe--candidate" from institution "stepup.example.com" with UUID "00000000-0000-0000-0000-000000000004"
+    And the user "urn:collab:person:stepup.example.com:joe--ra" has a vetted "yubikey"
+    And the user "urn:collab:person:stepup.example.com:joe--raa" has a vetted "yubikey"
+    And the user "urn:collab:person:institution-d.example.com:joe-d-raa" has a vetted "yubikey"
+    And the user "urn:collab:person:institution-d.example.com:joe--candidate" has a vetted "yubikey"
+    And the user "urn:collab:person:stepup.example.com:joe--ra" has the role "ra" for institution "stepup.example.com"
+    And the user "urn:collab:person:stepup.example.com:joe--raa" has the role "raa" for institution "stepup.example.com"
+    And the user "urn:collab:person:institution-d.example.com:joe-d-raa" has the role "raa" for institution "institution-d.example.com"
+
+
+  # Token page
+  Scenario: An anonymous user can not view the tokens page
+    Given I visit the "second-factors" page in the RA environment
+    Then I should see "Enter your username and password"
+
+  Scenario: RA can view the tokens page
+    Given I am logged in into the ra portal as "joe--ra" with a "yubikey" token
+    When I visit the "second-factors" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: RAA can view the tokens page
+    Given I am logged in into the ra portal as "joe--raa" with a "yubikey" token
+    When I visit the "second-factors" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: RAA from other institution can view the tokens page
+    Given I am logged in into the ra portal as "joe-d-raa" with a "yubikey" token
+    When I visit the "second-factors" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: SRAA can view the tokens page
+    Given I am logged in into the ra portal as "admin" with a "yubikey" token
+    And I switch to institution "stepup.example.com" with SRAA switcher
+    When I visit the "second-factors" page in the RA environment
+    Then the response status code should be 200
+
+
+  # RA-management page
+  Scenario: An anonymous user can not view the ra-management page
+    Given I visit the "management/ra" page in the RA environment
+    Then I should see "Enter your username and password"
+
+  Scenario: RA can not view the ra-management page
+    Given I am logged in into the ra portal as "joe--ra" with a "yubikey" token
+    When I visit the "management/ra" page in the RA environment
+    Then the response status code should be 403
+
+  Scenario: RAA can view the ra-management page
+    Given I am logged in into the ra portal as "joe--raa" with a "yubikey" token
+    When I visit the "management/ra" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: RAA from another institution can not view the ra-management page
+    Given I am logged in into the ra portal as "joe-d-raa" with a "yubikey" token
+    When I visit the "management/ra" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: SRAA can view the ra-management page
+    Given I am logged in into the ra portal as "admin" with a "yubikey" token
+    And I switch to institution "stepup.example.com" with SRAA switcher
+    When I visit the "management/ra" page in the RA environment
+    Then the response status code should be 200
+
+
+  # RA-management create page
+  Scenario: An anonymous user can not view the ra-management create page
+    Given I visit the "management/create-ra/00000000-0000-0000-0000-000000000004" page in the RA environment
+    Then I should see "Enter your username and password"
+
+  Scenario: RA can not view the ra-management create page
+    Given I am logged in into the ra portal as "joe--ra" with a "yubikey" token
+    When I visit the "management/create-ra/00000000-0000-0000-0000-000000000004" page in the RA environment
+    Then the response status code should be 403
+
+  Scenario: RAA can view the ra-management create page
+    Given I am logged in into the ra portal as "joe--raa" with a "yubikey" token
+    When I visit the "management/create-ra/00000000-0000-0000-0000-000000000004" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: RAA from another institution can not view the ra-management create page
+    Given I am logged in into the ra portal as "joe-d-raa" with a "yubikey" token
+    When I visit the "management/create-ra/00000000-0000-0000-0000-000000000004" page in the RA environment
+    Then the response status code should be 404
+
+  Scenario: SRAA can view the ra-management create page
+    Given I am logged in into the ra portal as "admin" with a "yubikey" token
+    And I switch to institution "stepup.example.com" with SRAA switcher
+    When I visit the "management/create-ra/00000000-0000-0000-0000-000000000004" page in the RA environment
+    Then the response status code should be 200
+
+
+  # RA-management amend page
+  Scenario: An anonymous user can not view the ra-management amend page
+    Given I visit the "management/amend-ra-information/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then I should see "Enter your username and password"
+
+  Scenario: RA can not view the ra-management amend page
+    Given I am logged in into the ra portal as "joe--ra" with a "yubikey" token
+    When I visit the "management/amend-ra-information/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then the response status code should be 403
+
+  Scenario: RAA can view the ra-management amend page
+    Given I am logged in into the ra portal as "joe--raa" with a "yubikey" token
+    When I visit the "management/amend-ra-information/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: RAA from institution-c can not view the ra-management amend page
+    Given I am logged in into the ra portal as "joe-d-raa" with a "yubikey" token
+    When I visit the "management/amend-ra-information/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then the response status code should be 404
+
+  Scenario: SRAA can view the ra-management amend page
+    Given I am logged in into the ra portal as "admin" with a "yubikey" token
+    And I switch to institution "stepup.example.com" with SRAA switcher
+    When I visit the "management/amend-ra-information/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then the response status code should be 200
+
+
+  # RA-management retract page
+  Scenario: An anonymous user can not view the ra-management retract page
+    Given I visit the "management/retract-registration-authority/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then I should see "Enter your username and password"
+
+  Scenario: RA can not view the ra-management retract page
+    Given I am logged in into the ra portal as "joe--ra" with a "yubikey" token
+    When I visit the "management/retract-registration-authority/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then the response status code should be 403
+
+  Scenario: RAA can view the ra-management retract page
+    Given I am logged in into the ra portal as "joe--raa" with a "yubikey" token
+    When I visit the "management/retract-registration-authority/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: RAA from another institution can not view the ra-management retract page
+    Given I am logged in into the ra portal as "joe-d-raa" with a "yubikey" token
+    When I visit the "management/retract-registration-authority/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then the response status code should be 404
+
+  Scenario: SRAA can view the ra-management retract page
+    Given I am logged in into the ra portal as "admin" with a "yubikey" token
+    And I switch to institution "stepup.example.com" with SRAA switcher
+    When I visit the "management/retract-registration-authority/00000000-0000-0000-0000-000000000001/stepup.example.com" page in the RA environment
+    Then the response status code should be 200
+
+
+  # RA-candidate page
+  Scenario: An anonymous user can not view the ra-candidate page
+    Given I visit the "management/search-ra-candidate" page in the RA environment
+    Then I should see "Enter your username and password"
+
+  Scenario: RA can not view the ra-candidate page
+    Given I am logged in into the ra portal as "joe--ra" with a "yubikey" token
+    When I visit the "management/search-ra-candidate" page in the RA environment
+    Then the response status code should be 403
+
+  Scenario: RAA can view the ra-candidate page
+    Given I am logged in into the ra portal as "joe--raa" with a "yubikey" token
+    When I visit the "management/search-ra-candidate" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: RAA from another institution can view the ra-candidate page
+    Given I am logged in into the ra portal as "joe--raa" with a "yubikey" token
+    When I visit the "management/search-ra-candidate" page in the RA environment
+    Then the response status code should be 200
+
+  Scenario: SRAA can view the ra-candidate page
+    Given I am logged in into the ra portal as "admin" with a "yubikey" token
+    And I switch to institution "stepup.example.com" with SRAA switcher
+    When I visit the "management/search-ra-candidate" page in the RA environment
+    Then the response status code should be 200


### PR DESCRIPTION
Add tests to validate if the expected ra(a)'s are authorized to view certain routes. Also test if they are not allowed to view certain routes.

This was done because before fga identities could only be made ra(a) for their own institution. This could be easily validated in RA only. Currently the authorization decision is made in both RA and in MW. For RA we should only detect the highest role level and in MW we should return results based on the currently active user or in case of an SRAA the active institution.

These changes are tested in the `ra_grants.feature` feature.