### PR TITLE
Fix behat selfservice session

### DIFF
--- a/tests/behat/config/behat.yml
+++ b/tests/behat/config/behat.yml
@@ -32,3 +32,7 @@ default:
                     goutte:
                         guzzle_parameters:
                             verify: False
+                ss:
+                    goutte:
+                        guzzle_parameters:
+                            verify: False

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -16,6 +16,7 @@ class FeatureContext implements Context
 {
         const SESSION_RA = 'ra';
         const SESSION_MW = 'mw';
+        const SESSION_SS = 'ss';
         const SESSION_DEFAULT = 'default';
     /**
      * @var \Behat\MinkExtension\Context\MinkContext
@@ -84,6 +85,7 @@ class FeatureContext implements Context
         // Set the testcookie, effectively putting the Stepup suite in test mode
         $this->minkContext->getSession()->setCookie('testcookie', 'testcookie');
         $this->minkContext->getSession('ra')->setCookie('testcookie', 'testcookie');
+        $this->minkContext->getSession('ss')->setCookie('testcookie', 'testcookie');
 
         $this->payloadFactory = new CommandPayloadFactory();
         $this->repository = new SecondFactorRepository();

--- a/tests/behat/features/bootstrap/SelfServiceContext.php
+++ b/tests/behat/features/bootstrap/SelfServiceContext.php
@@ -61,6 +61,8 @@ class SelfServiceContext implements Context
      */
     public function loginIntoSelfService()
     {
+        $this->minkContext->getMink()->setDefaultSessionName(FeatureContext::SESSION_SS);
+
         $this->minkContext->visit($this->selfServiceUrl);
 
         $this->authContext->authenticateWithIdentityProvider();
@@ -74,6 +76,8 @@ class SelfServiceContext implements Context
      */
     public function iAmLoggedInIntoTheSelfServicePortalAs($userName)
     {
+        $this->minkContext->getMink()->setDefaultSessionName(FeatureContext::SESSION_SS);
+
         // We visit the Self Service location url
         $this->minkContext->visit($this->selfServiceUrl);
         $this->authContext->authenticateWithIdentityProviderFor($userName);
@@ -186,9 +190,9 @@ class SelfServiceContext implements Context
     public function iVisitAPageInTheSelfServiceEnvironment($uri)
     {
         // The ra session is used to vet the token
-        $this->minkContext->getMink()->setDefaultSessionName(FeatureContext::SESSION_RA);
+        $this->minkContext->getMink()->setDefaultSessionName(FeatureContext::SESSION_SS);
 
-        // We visit the RA location url
+        // We visit the SS location url
         $this->minkContext->visit($this->selfServiceUrl.'/'.$uri);
     }
 

--- a/tests/behat/features/selfservice.feature
+++ b/tests/behat/features/selfservice.feature
@@ -4,7 +4,7 @@ Feature: A user manages his tokens in the selfservice portal
   I must be able to manage my second factor tokens
 
   Scenario: A user registers a token in selfservice
-    Given I am logged in into the selfservice portal
+    Given I am logged in into the selfservice portal as "joe-a1"
      When I register a new SMS token
       And I verify my e-mail address
       And I vet my second factor at the information desk


### PR DESCRIPTION
The session for selfservice needs to be separated. This was not done
in an earlier stage but it prevented from logging in again in a valid
context.