### PR TITLE
Replace PHP 5.6 with 7.2

### DIFF
--- a/roles/app/files/php-fpm.conf
+++ b/roles/app/files/php-fpm.conf
@@ -22,8 +22,8 @@ pid = /run/php-fpm/php-fpm.pid
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; in a local file.
-; Default Value: /var/log/php-fpm.log
-;error_log = /var/log/php-fpm/error.log
+; Default Value: /var/opt/remi/php72/log/php-fpm.log
+;error_log = /var/opt/remi/php72/log/php-fpm/error.log
 error_log = syslog
 
 ; syslog_facility is used to specify what type of program is logging the
@@ -43,6 +43,24 @@ error_log = syslog
 ; Possible Values: alert, error, warning, notice, debug
 ; Default Value: notice
 ;log_level = notice
+
+; Log limit on number of characters in the single line (log entry). If the
+; line is over the limit, it is wrapped on multiple lines. The limit is for
+; all logged characters including message prefix and suffix if present. However
+; the new line character does not count into it as it is present only when
+; logging to a file descriptor. It means the new line character is not present
+; when logging to syslog.
+; Default Value: 1024
+;log_limit = 4096
+
+; Log buffering specifies if the log line is buffered which means that the
+; line is written in a single write operation. If the value is false, then the
+; data is written directly into the file descriptor. It is an experimental
+; option that can potentionaly improve logging performance and memory usage
+; for some heavy logging scenarios. This option is ignored if logging to syslog
+; as it has to be always buffered.
+; Default value: yes
+;log_buffering = no
 
 ; If this number of child processes exit with SIGSEGV or SIGBUS within the time
 ; interval set by emergency_restart_interval then FPM will restart. A value
@@ -64,19 +82,18 @@ error_log = syslog
 ; Default Value: 0
 ;process_control_timeout = 0
 
-; The maximum number of processes FPM will fork. This has been design to control
+; The maximum number of processes FPM will fork. This has been designed to control
 ; the global number of processes when using dynamic PM within a lot of pools.
 ; Use it with caution.
 ; Note: A value of 0 indicates no limit
-
 ; Default Value: 0
 ;process.max = 128
 
 ; Specify the nice(2) priority to apply to the master process (only if set)
-; The value can vary from -19 (highest priority) to 20 (lower priority)
+; The value can vary from -19 (highest priority) to 20 (lowest priority)
 ; Note: - It will only work if the FPM master process is launched as root
 ;       - The pool process will inherit the master process priority
-;         unless it specified otherwise
+;         unless specified otherwise
 ; Default Value: no set
 ;process.priority = -19
 
@@ -100,8 +117,8 @@ daemonize = yes
 ; Default Value: not set (auto detection)
 ;events.mechanism = epoll
 
-; When FPM is build with systemd integration, specify the interval,
-; in second, between health report notification to systemd.
+; When FPM is built with systemd integration, specify the interval,
+; in seconds, between health report notification to systemd.
 ; Set to 0 to disable.
 ; Available Units: s(econds), m(inutes), h(ours)
 ; Default Unit: seconds
@@ -117,4 +134,5 @@ daemonize = yes
 ; used in logs and stats. There is no limitation on the number of pools which
 ; FPM can handle. Your system will tell you anyway :)
 
-; See /etc/php-fpm.d/*.conf
+; See /etc/opt/remi/php73/php-fpm.d/*.conf
+

--- a/roles/app/files/remi.repo
+++ b/roles/app/files/remi.repo
@@ -6,24 +6,6 @@ enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
 
-[remi-php55]
-name=Les RPM de remi de PHP 5.5 pour Enterprise Linux 7 - $basearch
-#baseurl=http://rpms.famillecollet.com/enterprise/7/php55/$basearch/
-mirrorlist=http://rpms.famillecollet.com/enterprise/7/php55/mirror
-# WARNING: If you enable this repository, you must also enable "remi"
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
-
-[remi-php56]
-name=Les RPM de remi de PHP 5.6 pour Enterprise Linux 7 - $basearch
-#baseurl=http://rpms.famillecollet.com/enterprise/7/php56/$basearch/
-mirrorlist=http://rpms.famillecollet.com/enterprise/7/php56/mirror
-# WARNING: If you enable this repository, you must also enable "remi"
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
-
 [remi-test]
 name=Les RPM de remi en test pour Enterprise Linux 7 - $basearch
 #baseurl=http://rpms.famillecollet.com/enterprise/7/test/$basearch/
@@ -33,30 +15,34 @@ enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
 
-[remi-debuginfo]
-name=Les RPM de remi pour Enterprise Linux 7 - $basearch - debuginfo
-baseurl=http://rpms.famillecollet.com/enterprise/7/debug-remi/$basearch/
+[remi-php72]
+name=Remi's PHP 7.2 RPM repository for Enterprise Linux 7 - $basearch
+#baseurl=http://rpms.remirepo.net/enterprise/7/php72/$basearch/
+#mirrorlist=https://rpms.remirepo.net/enterprise/7/php72/httpsmirror
+mirrorlist=http://cdn.remirepo.net/enterprise/7/php72/mirror
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
+
+[remi-php72-debuginfo]
+name=Remi's PHP 7.2 RPM repository for Enterprise Linux 7 - $basearch - debuginfo
+baseurl=http://rpms.remirepo.net/enterprise/7/debug-php72/$basearch/
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
 
-[remi-php55-debuginfo]
-name=Les RPM de remi de PHP 5.5 pour Enterprise Linux 7 - $basearch - debuginfo
-baseurl=http://rpms.famillecollet.com/enterprise/7/debug-php55/$basearch/
+[remi-php72-test]
+name=Remi's PHP 7.2 test RPM repository for Enterprise Linux 7 - $basearch
+#baseurl=http://rpms.remirepo.net/enterprise/7/test72/$basearch/
+#mirrorlist=https://rpms.remirepo.net/enterprise/7/test72/httpsmirror
+mirrorlist=http://cdn.remirepo.net/enterprise/7/test72/mirror
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
 
-[remi-php56-debuginfo]
-name=Les RPM de remi de PHP 5.6 pour Enterprise Linux 7 - $basearch - debuginfo
-baseurl=http://rpms.famillecollet.com/enterprise/7/debug-php56/$basearch/
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi
-
-[remi-test-debuginfo]
-name=Les RPM de remi en test pour Enterprise Linux 7 - $basearch - debuginfo
-baseurl=http://rpms.famillecollet.com/enterprise/7/debug-test/$basearch/
+[remi-php72-test-debuginfo]
+name=Remi's PHP 7.2 test RPM repository for Enterprise Linux 7 - $basearch - debuginfo
+baseurl=http://rpms.remirepo.net/enterprise/7/debug-test72/$basearch/
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-remi

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -6,7 +6,6 @@
 - name: Enable REMI repo
   copy: src=remi.repo dest=/etc/yum.repos.d/remi.repo
 
-
 - name: Create deploy user
   user: name={{app_deploy_user}} state=present
 
@@ -18,6 +17,14 @@
     key: "{{ app_deploy_user_ssh_key }}"
   when:  app_deploy_user_ssh_key is defined
 
+# Enable php72 as the default php version.
+- name: Install Yum utils
+  yum:
+    name:
+      - yum-utils
+
+- name: enable remi-php72
+  shell: yum-config-manager --enable remi-php72
 
 # node.less is used by app/console assetic:dump
 # sendmail is used for sending mail from localhost (enabled in default config)
@@ -38,15 +45,12 @@
       - php-bcmath
       - php-gmp
       - php-pecl-memcache
+      - php-pecl-apcu-bc
       - nodejs
       - nodejs-less.noarch
       - sendmail
       - sendmail-cf
     state: present
-
-# TODO: Why isn't php-gmp beining installed by the previous yum task?
-- name: Fix for php-gmp not being installed
-  yum: name=php-gmp state=present
 
 # Look for sendmail smarthost
 - name: Configure sendmail with smarthost
@@ -56,20 +60,15 @@
   notify:
     - reload sendmail
 
-# TODO: Why is this here ???
-# Build sendmail config file from template
-#- name: Configure sendmail
-#  command: make -C /etc/mail
-#  when: (sendmail_smarthost is defined) and (sendmail_smarthost_result|changed)
-
-# php-gd requires libgd (>2.1.1) from remi repo
-- name: Install php-gd
-  yum: name=php-gd state=present enablerepo=remi
-
 - name: Put php.ini
   template: src='php.ini.j2' dest='/etc/php.ini'
   notify:
     - restart php-fpm
+
+- name: Enable php-fpm
+  service:
+    name: php-fpm
+    enabled: yes
 
 # Remove default distro conf files
 - name: Remove known default distro files in /etc/nginxconf.d/ and /etc/php-fpm.d/


### PR DESCRIPTION
Some highlights
* PHP 7.2 is installed from the REMI repositories. 
* php72-php-fpm is used
* The default php executable is set to use php72
