### PR TITLE
Fix php72-fpm not starting when no pools are configured

### DIFF
--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -150,6 +150,13 @@
   vars: { component_name: keyserver,   vhost_name: "{{ keyserver_vhost_name }}" }
   when: "inventory_hostname in groups['stepup-keyserver']"
 
+- find: paths='/etc/opt/remi/php72/php-fpm.d/' patterns="*.conf"
+  register: php72pools
+
+- name: Add default php72-fpm config if no php72-fpm pools are configured
+  copy: src='www.conf' dest='/etc/opt/remi/php72/php-fpm.d/www.conf'
+  when: php72pools.matched < 1
+
 # Add vhost for running simplesaml php for developement
 - include: vhost.yml
   vars: { component_name: ssp,   vhost_name: "{{ ssp_vhost_name }}" }


### PR DESCRIPTION
This should fix php72-fpm errors when running the app role and nog php72 applications are present yet