### PR TITLE
Improve php7 migration

### DIFF
--- a/roles/app/defaults/main.yml
+++ b/roles/app/defaults/main.yml
@@ -1,0 +1,1 @@
+needphp7: False

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -1,3 +1,9 @@
+
+- name: Check if PHP7 is needed
+  set_fact:
+    needphp7: True
+  when: "'stepup-webauthn' in group_names or 'stepup-azuremfa' in group_names"
+
 # Install the "REMI" repo which contain newer php packages that override the default
 # that come with the distro (CentOS7: 5.4; CentOS6: 5.3)
 - name: Install REMI repo
@@ -5,7 +11,6 @@
 
 - name: Enable REMI repo
   copy: src=remi.repo dest=/etc/yum.repos.d/remi.repo
-
 
 - name: Create deploy user
   user: name={{app_deploy_user}} state=present
@@ -18,7 +23,6 @@
     key: "{{ app_deploy_user_ssh_key }}"
   when:  app_deploy_user_ssh_key is defined
 
-
 # node.less is used by app/console assetic:dump
 # sendmail is used for sending mail from localhost (enabled in default config)
 - name: Install nginx, php-(cli,fpm), node.less, smtpd, mysql client libs, bzip2
@@ -27,7 +31,10 @@
       - mysql
       - bzip2
       - nginx
-
+      - nodejs
+      - nodejs-less.noarch
+      - sendmail
+      - sendmail-cf
       # PHP 5.6 from remi-php56 repo. These override the centos base php versions
       # Config is in the centos default locations (/etc/)
       - php-fpm
@@ -42,6 +49,9 @@
       - php-gmp
       - php-pecl-memcache
 
+- name: Install PHP7 components if needed
+  yum:
+    name:
       # PHP 7.2 from remi-safe repo. These are installed alongside existing (centos / remi-php56) versions
       # Config in /opt/remi/php72
       - php72-php-fpm
@@ -56,13 +66,8 @@
       - php72-php-gmp
       - php72-php-pecl-memcache
       - php72-php-sodium
-
-      - nodejs
-      - nodejs-less.noarch
-      - sendmail
-      - sendmail-cf
     state: present
-
+  when: needphp7
 
 # Look for sendmail smarthost
 - name: Configure sendmail with smarthost
@@ -82,11 +87,10 @@
     - restart php-fpm
 
 # Remove default distro conf files
-- name: Remove known default distro files in /etc/nginxconf.d/, /etc/php-fpm.d/ and /etc/opt/remi/php72/php-fpm.d/
+- name: Remove known default distro files in /etc/nginxconf.d/ and /etc/php-fpm.d/
   file: path={{item}} state=absent
   with_items:
   - /etc/php-fpm.d/www.conf
-  - /etc/opt/remi/php72/php-fpm.d/www.conf
   - /etc/nginx/conf.d/default.conf
   - /etc/nginx/conf.d/ssl.conf
   - /etc/nginx/conf.d/virtual.conf
@@ -94,7 +98,14 @@
   #- restart httpd
   - restart nginx
   - restart php-fpm
+
+- name: Remove known default distro files /etc/opt/remi/php72/php-fpm.d/
+  file: path={{item}} state=absent
+  with_items:
+  - /etc/opt/remi/php72/php-fpm.d/www.conf
+  notify:
   - restart php72-php-fpm
+  when: needphp7
 
 - name: Put /etc/php-fpm.conf
   copy: src='php-fpm.conf' dest='/etc/php-fpm.conf'
@@ -105,6 +116,7 @@
   copy: src='php72-php-fpm.conf' dest='/etc/opt/remi/php72/php-fpm.conf'
   notify:
     - restart php72-php-fpm
+  when: needphp7
 
 - name: Put nginx.conf
   template: src='nginx.conf.j2' dest='/etc/nginx/nginx.conf'
@@ -127,28 +139,28 @@
 # Create vhosts for stepup components
 - include: php72-vhost-symfony4.yml
   vars: { component_name: webauthn,  vhost_name: "{{ webauthn_vhost_name }}" }
-  when: "inventory_hostname in groups['stepup-webauthn']"
+  when: "'stepup-webauthn' in group_names"
 - include: php72-vhost-symfony4.yml
   vars: { component_name: azuremfa,  vhost_name: "{{ azuremfa_vhost_name }}" }
-  when: "inventory_hostname in groups['stepup-azuremfa']"
+  when: "'stepup-azuremfa' in group_names"
 - include: vhost.yml
   vars: { component_name: middleware,  vhost_name: "{{ middleware_vhost_name }}" }
-  when: "inventory_hostname in groups['stepup-middleware']"
+  when: "'stepup-middleware' in group_names"
 - include: vhost.yml
   vars: { component_name: gateway,     vhost_name: "{{ gateway_vhost_name }}" }
-  when: "inventory_hostname in groups['stepup-gateway']"
+  when: "'stepup-gateway' in group_names"
 - include: vhost.yml
   vars: { component_name: selfservice, vhost_name: "{{ selfservice_vhost_name }}" }
-  when: "inventory_hostname in groups['stepup-selfservice']"
+  when: "'stepup-selfservice' in group_names"
 - include: vhost.yml
   vars: { component_name: ra,          vhost_name: "{{ ra_vhost_name }}" }
-  when: "inventory_hostname in groups['stepup-ra']"
+  when: "'stepup-ra' in group_names"
 - include: vhost.yml
   vars: { component_name: tiqr,        vhost_name: "{{ tiqr_vhost_name }}" }
-  when: "inventory_hostname in groups['stepup-tiqr']"
+  when: "'stepup-tiqr' in group_names"
 - include: vhost.yml
   vars: { component_name: keyserver,   vhost_name: "{{ keyserver_vhost_name }}" }
-  when: "inventory_hostname in groups['stepup-keyserver']"
+  when: "'stepup-keyserver' in group_names"
 
 # Add vhost for running simplesaml php for developement
 - include: vhost.yml
@@ -169,9 +181,13 @@
   with_items:
   - nginx
   - php-fpm
-  - php72-php-fpm
   - sendmail
 
+- name: Start and enable php7-fpm if needed
+  service: name={{item}} state=started enabled=true
+  with_items:
+  - php72-php-fpm
+  when: needphp7
 
 - name: Put rsyslog config for nginx
   copy: src=rsyslog_nginx.conf dest=/etc/rsyslog.d/nginx.conf


### PR DESCRIPTION
Only install php7 modules and config if needed by any of the components. 
Improve vhost requirements to deal with missing group_names.