### PR TITLE
Fix dev environment deployment

### DIFF
--- a/environments/template/environment.conf
+++ b/environments/template/environment.conf
@@ -32,6 +32,8 @@ PASSWORDS=(
   "database_tiqr_deploy"
   "database_u2f"
   "manage_kibana"
+  "database_webauthn"
+  "database_webauthn_deploy"
 )
 
 # Length of generated secrets in characters

--- a/roles/dev/tasks/main.yml
+++ b/roles/dev/tasks/main.yml
@@ -32,8 +32,8 @@
 ## Composer ##
 
 # Install systemwide composer in /usr/local/bin
-- name: Download /usr/local/bin/composer from https://getcomposer.org/composer.phar
-  get_url: url=https://getcomposer.org/composer.phar dest=/usr/local/bin/composer mode=555 owner=root group=root
+- name: Download /usr/local/bin/composer from https://getcomposer.org/composer-stable.phar
+  get_url: url=https://getcomposer.org/composer-stable.phar dest=/usr/local/bin/composer mode=555 owner=root group=root
 
 - name: Put /etc/rc.d/rc.local
   copy: src=rc.local dest=/etc/rc.d/rc.local mode=550

--- a/roles/stepup-gateway/tasks/main.yml
+++ b/roles/stepup-gateway/tasks/main.yml
@@ -24,13 +24,10 @@
   args:
       chdir: "{{ component_dir_name }}"
 
-- name: mopa:bootstrap:symlink:less
-  command: php app/console mopa:bootstrap:symlink:less --env=prod {{ debug_flag }}
-  args:
-      chdir: "{{ component_dir_name }}"
-
 - name: Dump Assetic Assets
-  shell: php {{ component_dir_name }}/app/console assetic:dump --env=prod {{ debug_flag }}
+  command: php app/console assetic:dump --env=prod {{ debug_flag }}
+  args:
+    chdir: "{{ component_dir_name }}"
 
 - name: Clear and warmup cache
   command: php app/console cache:clear --env=prod {{ debug_flag }}

--- a/roles/stepup-keyserver/tasks/main.yml
+++ b/roles/stepup-keyserver/tasks/main.yml
@@ -1,6 +1,6 @@
 # Infra stuff for key server
 - name: Create /app/config/ directory
-  file: path={{ component_dir_name }}/app/config/ state=directory group={{ component_name }} mode=755
+  file: path={{ component_dir_name }}/app/config/ state=directory group={{ component_group }} mode={{ component_mode_755 }}
 
 - name: Put parameters.yml
   template: src=parameters.yml.j2 dest={{ component_dir_name }}/app/config/parameters.yml mode={{ component_mode_640 }} group={{ component_group }}

--- a/roles/stepup-ra/tasks/main.yml
+++ b/roles/stepup-ra/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: Clear and warmup cache
   command: php app/console cache:clear --env=prod {{ debug_flag }}
   args:
-      chdir: "{{ component_dir_name }}"
+    chdir: "{{ component_dir_name }}"
   when: not (develop | default(false))
 
 - name: Restrict app dir to the application


### PR DESCRIPTION
During the reprovisioning of a a development box I encountered some
quircks that needed to be fixed to be able to update my dev box.

- the webauthn component was missing in the environment.conf
- composer 2.0 broke SSP installation due to invalid composer.json
- bootstrap was removed from GW but was still being installed
- ~~Keyserver master uses older symfony (app/console vs bin/console)~~