### PR TITLE
Use php72 for RA and MW

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -142,3 +142,33 @@
       component_vhost_name: "{{ webauthn_vhost_name }}"
       component_dir_name: "/opt/stepup/{{ component_tarball_name | basename | regex_replace('^(.*)\\.tar\\.bz2$', '\\1') }}"
       stable_nonce: "{{ component_tarball_name | basename | regex_replace('^.*-(.{8}).{32}\\.tar\\.bz2$', '\\1') }}"
+
+
+# Demo GSSP's only for development purposes
+- name: Install Stepup-Demo-GSSP
+  hosts: stepup-demo-gssp
+  become: True
+  tags: stepup-demo-gssp
+
+  roles:
+    - stepup-gssp-example
+    - deploy
+
+  vars:
+    component_name: demo-gssp
+    component_vhost_name: "{{ demo_gssp_vhost_name }}"
+    stable_nonce: "develop"
+
+- name: Install Stepup-Demo-GSSP 2
+  hosts: stepup-demo-gssp-2
+  become: True
+  tags: stepup-demo-gssp-2
+
+  roles:
+    - stepup-gssp-example
+    - deploy
+
+  vars:
+    component_name: demo-gssp-2
+    component_vhost_name: "{{ demo_gssp_2_vhost_name }}"
+    stable_nonce: "develop"

--- a/environments/template/group_vars/all.yml
+++ b/environments/template/group_vars/all.yml
@@ -51,7 +51,11 @@ gateway_vhost_name: gateway.stepup.example.com
 tiqr_vhost_name: tiqr.stepup.example.com
 webauthn_vhost_name: webauthn.stepup.example.com
 keyserver_vhost_name: keyserver.stepup.example.com
+
 ssp_vhost_name: ssp.stepup.example.com # Used by the "dev" role only
+demo_gssp_vhost_name: demo-gssp.stepup.example.com # Used by the "dev" role only
+demo_gssp_2_vhost_name: demo-gssp-2.stepup.example.com # Used by the "dev" role only
+
 
 # Domain for the locale cookie that is set by gateway, selfservice and ra and that is used to share the
 # user's locale preference with other (stepup) components

--- a/environments/template/group_vars/all.yml
+++ b/environments/template/group_vars/all.yml
@@ -50,6 +50,7 @@ ra_vhost_name: ra.stepup.example.com
 gateway_vhost_name: gateway.stepup.example.com
 tiqr_vhost_name: tiqr.stepup.example.com
 webauthn_vhost_name: webauthn.stepup.example.com
+azuremfa_vhost_name: azuremfa.stepup.example.com
 keyserver_vhost_name: keyserver.stepup.example.com
 
 ssp_vhost_name: ssp.stepup.example.com # Used by the "dev" role only

--- a/environments/template/group_vars/dev.yml
+++ b/environments/template/group_vars/dev.yml
@@ -19,3 +19,17 @@ ssp_sp_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/simplesaml_sp.crt
 
 ssp_sp2_privatekey: "{{ lookup('file', inventory_dir+'/saml_cert/simplesaml_sp2.key') }}"
 ssp_sp2_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/simplesaml_sp2.crt') }}"
+
+# Enabled development second factors
+stepup_enabled_generic_second_factors:
+  tiqr:
+    loa: 2
+  demo-gssp:
+    loa: 2
+  demo-gssp-2:
+    loa: 2
+
+# Skip the prove token possession step
+skip_prove_possession_second_factors:
+  - gssp-2
+

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check if PHP7 is needed
   set_fact:
     needphp7: True
-  when: "'stepup-webauthn' in group_names or 'stepup-azuremfa' in group_names"
+  when: "'stepup-webauthn' in group_names or 'stepup-azuremfa' in group_names or 'stepup-ra' in group_names or 'stepup-middleware' in group_names"
 
 # Install the "REMI" repo which contain newer php packages that override the default
 # that come with the distro (CentOS7: 5.4; CentOS6: 5.3)
@@ -143,7 +143,7 @@
 - include: php72-vhost-symfony4.yml
   vars: { component_name: azuremfa,  vhost_name: "{{ azuremfa_vhost_name }}" }
   when: "'stepup-azuremfa' in group_names"
-- include: vhost.yml
+- include: php72-vhost-symfony4-flex.yml
   vars: { component_name: middleware,  vhost_name: "{{ middleware_vhost_name }}" }
   when: "'stepup-middleware' in group_names"
 - include: vhost.yml
@@ -152,7 +152,7 @@
 - include: vhost.yml
   vars: { component_name: selfservice, vhost_name: "{{ selfservice_vhost_name }}" }
   when: "'stepup-selfservice' in group_names"
-- include: vhost.yml
+- include: php72-vhost-symfony4-flex.yml
   vars: { component_name: ra,          vhost_name: "{{ ra_vhost_name }}" }
   when: "'stepup-ra' in group_names"
 - include: vhost.yml

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -167,14 +167,12 @@
   vars: { component_name: ssp,   vhost_name: "{{ ssp_vhost_name }}" }
   when: "inventory_hostname in groups['dev']"
 
-
 # Because nginx will restart with an invalid config without service detecting this, so we test the config  first
 - name: Test nginx config
   command: /sbin/nginx -t
   register: nginx_test
   changed_when: False
   failed_when: nginx_test.rc > 0
-
 
 - name: Start and enable nginx & php-fpm & smtp services
   service: name={{item}} state=started enabled=true

--- a/roles/app/tasks/php72-vhost-symfony4-flex.yml
+++ b/roles/app/tasks/php72-vhost-symfony4-flex.yml
@@ -17,10 +17,10 @@
 # Create a default app
 # When no app is installed yet in the webdirectory then a link to the default app is created
 - name: Create default app directory for {{ vhost_name }}
-  file: path=/opt/default/{{ vhost_name }}/web/ state=directory
+  file: path=/opt/default/{{ vhost_name }}/public/ state=directory
 
-- name: Create default /opt/default/{{ vhost_name }}/web/app.php
-  template: src='httpd-index.php.j2' dest='/opt/default/{{ vhost_name }}/web/app.php'
+- name: Create default /opt/default/{{ vhost_name }}/public/app.php
+  template: src='httpd-index.php.j2' dest='/opt/default/{{ vhost_name }}/public/app.php'
 
 
 - stat: path=/opt/www/{{ vhost_name }}
@@ -33,10 +33,9 @@
 
 # Put httpd vhost config
 - name: Put httpd vhost config for {{ vhost_name }} (php72)
-  action: template src='php72-nginx-vhost.conf.j2' dest='/etc/nginx/conf.d/{{ vhost_name }}.conf'
+  action: template src='php72-nginx-vhost-symfony4-flex.conf.j2' dest='/etc/nginx/conf.d/{{ vhost_name }}.conf'
   notify:
     - restart nginx
-
 
 # Put fpm config
 - name: Put php72-php-fpm config

--- a/roles/app/tasks/php72-vhost-symfony4-flex.yml
+++ b/roles/app/tasks/php72-vhost-symfony4-flex.yml
@@ -37,6 +37,13 @@
   notify:
     - restart nginx
 
+- name: Remove php5 php-fpm config if present
+  file:
+    path: '/etc/php-fpm.d/{{ vhost_name }}.conf'
+    state: absent
+  notify:
+    - restart php-fpm
+
 # Put fpm config
 - name: Put php72-php-fpm config
   template: src='php72-fpm-pool.conf.j2' dest='/etc/opt/remi/php72/php-fpm.d/{{ vhost_name }}.conf'

--- a/roles/app/tasks/php72-vhost-symfony4.yml
+++ b/roles/app/tasks/php72-vhost-symfony4.yml
@@ -37,6 +37,12 @@
   notify:
     - restart nginx
 
+- name: Remove php5 php-fpm config if present
+  file:
+    path: '/etc/php-fpm.d/{{ vhost_name }}.conf'
+    state: absent
+  notify:
+    - restart php-fpm
 
 # Put fpm config
 - name: Put php72-php-fpm config

--- a/roles/app/tasks/php72-vhost-symfony4.yml
+++ b/roles/app/tasks/php72-vhost-symfony4.yml
@@ -33,7 +33,7 @@
 
 # Put httpd vhost config
 - name: Put httpd vhost config for {{ vhost_name }} (php72)
-  action: template src='php72-nginx-vhost.conf.j2' dest='/etc/nginx/conf.d/{{ vhost_name }}.conf'
+  action: template src='php72-nginx-vhost-symfony4.conf.j2' dest='/etc/nginx/conf.d/{{ vhost_name }}.conf'
   notify:
     - restart nginx
 

--- a/roles/app/tasks/php72-vhost.yml
+++ b/roles/app/tasks/php72-vhost.yml
@@ -30,13 +30,18 @@
   file: src=/opt/default/{{ vhost_name }} dest=/opt/www/{{ vhost_name }} state=link force=no
   when: (r.stat.exists == false)
 
-
 # Put httpd vhost config
 - name: Put httpd vhost config for {{ vhost_name }} (php72)
   action: template src='php72-nginx-vhost.conf.j2' dest='/etc/nginx/conf.d/{{ vhost_name }}.conf'
   notify:
     - restart nginx
 
+- name: Remove php5 php-fpm config if present
+  file:
+    path: '/etc/php-fpm.d/{{ vhost_name }}.conf'
+    state: absent
+  notify:
+    - restart php-fpm
 
 # Put fpm config
 - name: Put php72-php-fpm config

--- a/roles/app/templates/php72-nginx-vhost-symfony4-flex.conf.j2
+++ b/roles/app/templates/php72-nginx-vhost-symfony4-flex.conf.j2
@@ -1,0 +1,85 @@
+server {
+    listen       80;
+    server_name  {{ vhost_name }};
+    root /opt/www/{{ vhost_name }}/public;
+
+    error_log /var/log/nginx/{{ component_name }}_error.log;
+    error_log syslog:server=unix:/dev/log,tag=nginx_error_{{ component_name }},nohostname;
+    access_log /var/log/nginx/{{ component_name }}_access.log combinedProxy;
+    access_log syslog:server=unix:/dev/log,tag=nginx_access_{{ component_name }},nohostname combinedProxy;
+
+    location /heartbeat {
+        return 200 'Heartbeat for {{ vhost_name }}';
+    }
+
+    # Get the IP address from the X-Forwarded-For header and store it in $remote_addr, but
+    # only if the connection (i.e. the current $remote_addr) is from
+    # one of the IPs specified in "set_real_ip_from" below.
+    {% if 'proxy' in group_names %}
+        set_real_ip_from  127.0.0.1;
+    {% endif %}
+    {% for ip in lb_addresses %}
+        set_real_ip_from  {{ ip }};
+    {% endfor %}
+    real_ip_header    X-Forwarded-For;
+    real_ip_recursive off;
+
+    {# Configuration for stepup components #}
+    {% if 'dev' in group_names %}
+      {# Use development version of the component by using setting a different symfony env var. This enables
+         development features like the symfony development toolbar #}
+      location / {
+          # try to serve file directly, fallback to index.php
+          try_files $uri /index.php$is_args$args;
+      }
+
+      location ~ ^/index.php(/|$) {
+          # If testcookie is set use app_test.php
+          set $context dev;
+          if ($cookie_testcookie) {
+            set $context smoketest;
+          }
+
+          fastcgi_pass unix:/var/run/php-fpm/{{ component_name }}.socket;
+          fastcgi_split_path_info ^(.+\.php)(/.*)$;
+          # Include fastcgi_params from /etc/nginx/fastcgi_params, then
+          # override some of them
+          include fastcgi_params;
+          fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+          fastcgi_param HTTPS on;
+          fastcgi_param APP_ENV $context;
+      }
+      {# Finally, disallow opening php files outside of app_dev.php #}
+      location ~* \.php$ {
+          return 404;
+      }
+    {% else %}
+      {# Producation config for stepup components #}
+      location / {
+          # try to serve file directly, fallback to app.php
+          try_files $uri /index.php$is_args$args;
+      }
+
+      location ~ ^/index\.php(/|$) {
+          fastcgi_pass unix:/var/run/php-fpm/{{ component_name }}.socket;
+          fastcgi_split_path_info ^(.+\.php)(/.*)$;
+          # Include fastcgi_params from /etc/nginx/fastcgi_params, then
+          # override some of them
+          include fastcgi_params;
+          fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+          fastcgi_param HTTPS on;
+          fastcgi_param APP_ENV prod;
+      }
+
+      {# Finally, disallow opening php files outside of app.php #}
+      {# For authentication with old tiqr accounts /tiqr.php and /tiqr/tiqr.php must be routed to app.php so exempt those. #}
+          {% if 'stepup-tiqr' in group_names %}
+      location ~* ^(?!/(tiqr/)?tiqr\.php$).*\.php$ {
+          {% else %}
+      location ~* .php$ {
+          {% endif %}
+          return 404;
+      }
+
+    {% endif %}
+}

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -1,0 +1,1 @@
+needphp7: False

--- a/roles/dev/tasks/main.yml
+++ b/roles/dev/tasks/main.yml
@@ -38,12 +38,21 @@
 - name: Put /etc/rc.d/rc.local
   copy: src=rc.local dest=/etc/rc.d/rc.local mode=550
 
-## Yarn ##
+## Nodejs / NPM / Yarn stack ##
 
-# Required for dev install of Symfony 3 components
+# Needed to build the frontend assets in development
+- name: Add Nodesource repositories for Node.js
+  yum:
+    name: "https://rpm.nodesource.com/pub_12.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    state: present
 
-- name: Install yarn
-  shell: npm install -g yarn
+- name: Ensure Node.js and npm are installed
+  yum:
+    name:
+      - "nodejs-12*"
+    state: latest
+    enablerepo: nodesource
+
 
 ## XDebug ##
 

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -53,3 +53,20 @@
     proxy_certificate: "{{ proxy_keyserver_certificate }}"
     proxy_key: "{{ proxy_keyserver_key }}"
   when: "inventory_hostname in groups['stepup-keyserver']"
+
+
+- include: proxy.yml
+  vars:
+    vhost_name: "{{ demo_gssp_vhost_name }}"
+    component_name: demogssp
+    proxy_certificate: "{{ proxy_tiqr_certificate }}"
+    proxy_key: "{{ proxy_tiqr_key }}"
+  when: "inventory_hostname in groups['stepup-demo-gssp']"
+
+- include: proxy.yml
+  vars:
+    vhost_name: "{{ demo_gssp_2_vhost_name }}"
+    component_name: demogssp2
+    proxy_certificate: "{{ proxy_tiqr_certificate }}"
+    proxy_key: "{{ proxy_tiqr_key }}"
+  when: "inventory_hostname in groups['stepup-demo-gssp-2']"

--- a/roles/stepup-azure-mfa/tasks/main.yml
+++ b/roles/stepup-azure-mfa/tasks/main.yml
@@ -38,7 +38,7 @@
   file: path={{item}} group={{ component_group }} mode={{ component_mode_770 }} recurse=yes
   with_items:
   - "{{ component_dir_name }}/var/cache"
-  - "{{ component_dir_name }}/var/logs"
+  - "{{ component_dir_name }}/var/log"
   when: not (develop | default(false))
 
 

--- a/roles/stepup-gssp-example/tasks/main.yml
+++ b/roles/stepup-gssp-example/tasks/main.yml
@@ -1,0 +1,20 @@
+# Install demo gssp component
+
+- name: Exit if not develop
+  fail: msg="You should never install the demo gssp in production"
+  when: not (develop | default(false))
+
+
+- name: Copy .env file
+  copy: remote_src=True src={{ component_dir_name }}/.env.ci dest={{ component_dir_name }}/.env
+
+
+- name: Put parameters.yml
+  template: src={{ item }}.j2 dest={{ component_dir_name }}/config/packages/{{ item }} mode=666
+  with_items:
+    - parameters.yaml
+
+
+# Finish
+- name: Activate component
+  file: src={{ component_dir_name }} dest=/opt/www/{{ component_vhost_name }} state=link

--- a/roles/stepup-gssp-example/templates/parameters.yaml.j2
+++ b/roles/stepup-gssp-example/templates/parameters.yaml.j2
@@ -1,0 +1,14 @@
+# This file is a "template" of what your parameters.yml file should look like
+# Set parameters here that may be different on each deployment target of the app, e.g. development, staging, production.
+# https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
+
+parameters:
+    saml_idp_publickey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
+    saml_idp_privatekey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'
+    saml_metadata_publickey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
+    saml_metadata_privatekey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'
+    saml_remote_sp_entity_id: 'https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/metadata.php/default-sp'
+    saml_remote_sp_sso_url: '"https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/saml2-acs.php/default-sp"'
+    saml_remote_sp_certificate: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-gssp-bundle/src/Resources/keys/pieter.aai.surfnet.nl.pem'
+    saml_remote_sp_acs: 'https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/saml2-acs.php/default-sp'
+

--- a/roles/stepup-middleware/tasks/main.yml
+++ b/roles/stepup-middleware/tasks/main.yml
@@ -1,7 +1,7 @@
 # Infra suff for middleware
 
-- name: Put parameters.yml
-  template: src=parameters.yml.j2 dest={{ component_dir_name }}/config/legacy/parameters.yml mode={{ component_mode_640 }} group={{ component_group }}
+- name: Put parameters.yaml
+  template: src=parameters.yml.j2 dest={{ component_dir_name }}/config/legacy/parameters.yaml mode={{ component_mode_640 }} group={{ component_group }}
 
 - name: Clear and warmup cache
   command: php bin/console cache:clear --env=prod {{ debug_flag }}

--- a/roles/stepup-middleware/tasks/main.yml
+++ b/roles/stepup-middleware/tasks/main.yml
@@ -4,7 +4,7 @@
   template: src=parameters.yml.j2 dest={{ component_dir_name }}/config/legacy/parameters.yaml mode={{ component_mode_640 }} group={{ component_group }}
 
 - name: Clear and warmup cache
-  command: php bin/console cache:clear --env=prod {{ debug_flag }}
+  command: php72 bin/console cache:clear --env=prod {{ debug_flag }}
   args:
       chdir: "{{ component_dir_name }}"
   when: not (develop | default(false))

--- a/roles/stepup-middleware/tasks/main.yml
+++ b/roles/stepup-middleware/tasks/main.yml
@@ -19,7 +19,7 @@
   file: path={{item}} group={{ component_group }} mode={{ component_mode_770 }} recurse=yes
   with_items:
   - "{{ component_dir_name }}/var/cache"
-  - "{{ component_dir_name }}/var/logs"
+  - "{{ component_dir_name }}/var/log"
   when: not (develop | default(false))
 
 - name: Put middleware configuration scripts in /root/

--- a/roles/stepup-middleware/tasks/main.yml
+++ b/roles/stepup-middleware/tasks/main.yml
@@ -1,15 +1,10 @@
 # Infra suff for middleware
 
 - name: Put parameters.yml
-  template: src=parameters.yml.j2 dest={{ component_dir_name }}/app/config/parameters.yml mode={{ component_mode_640 }} group={{ component_group }}
-
-- name: assets:install
-  command: php app/console assets:install --symlink --env=prod {{ debug_flag }}
-  args:
-      chdir: "{{ component_dir_name }}"
+  template: src=parameters.yml.j2 dest={{ component_dir_name }}/config/legacy/parameters.yml mode={{ component_mode_640 }} group={{ component_group }}
 
 - name: Clear and warmup cache
-  command: php app/console cache:clear --env=prod {{ debug_flag }}
+  command: php bin/console cache:clear --env=prod {{ debug_flag }}
   args:
       chdir: "{{ component_dir_name }}"
   when: not (develop | default(false))
@@ -17,14 +12,14 @@
 - name: Restrict app dir to the application
   file: path={{item}} group={{ component_group }} mode="o=" recurse=yes
   with_items:
-  - "{{ component_dir_name }}/app"
+  - "{{ component_dir_name }}/var"
   when: not (develop | default(false))
 
 - name: Grant app write access to cache and log dirs
   file: path={{item}} group={{ component_group }} mode={{ component_mode_770 }} recurse=yes
   with_items:
-  - "{{ component_dir_name }}/app/cache"
-  - "{{ component_dir_name }}/app/logs"
+  - "{{ component_dir_name }}/var/cache"
+  - "{{ component_dir_name }}/var/logs"
   when: not (develop | default(false))
 
 - name: Put middleware configuration scripts in /root/

--- a/roles/stepup-middleware/templates/01-middleware-db_migrate.sh.j2
+++ b/roles/stepup-middleware/templates/01-middleware-db_migrate.sh.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 pushd /opt/www/{{ middleware_vhost_name }}
-php app/console middleware:migrations:migrate --env=prod
+php72 ./bin/console doctrine:migrations:migrate --env=prod --em=deploy
 popd

--- a/roles/stepup-middleware/templates/parameters.yml.j2
+++ b/roles/stepup-middleware/templates/parameters.yml.j2
@@ -10,7 +10,6 @@ parameters:
     # The database server version is used in the dbal configuration and is required to prevent issues when the database
     # connection is booted. See https://github.com/doctrine/DoctrineBundle/issues/351 for more details on this.
     # Also see: https://symfony.com/doc/current/reference/configuration/doctrine.html#doctrine-dbal-configuration
-    database_server_version: 5.6
     database_middleware_name:     {{ database_middleware_name }}
     database_middleware_user:     {{ database_middleware_user }}
     database_middleware_password: {{ database_middleware_password | vault(vault_keydir)}}

--- a/roles/stepup-middleware/templates/parameters.yml.j2
+++ b/roles/stepup-middleware/templates/parameters.yml.j2
@@ -60,3 +60,7 @@ parameters:
     # institution config (middleware api). The value configured in the parameters.yml will be used as the
     # fallback/default value.
     number_of_tokens_per_identity: 1
+    skip_prove_possession_second_factors:
+    {% for value in skip_prove_possession_second_factors %}
+      - {{ value }}
+    {% endfor %}

--- a/roles/stepup-middleware/templates/parameters.yml.j2
+++ b/roles/stepup-middleware/templates/parameters.yml.j2
@@ -24,8 +24,8 @@ parameters:
 
     mailer_transport:  smtp
     mailer_host:       127.0.0.1
-    mailer_user:       ~
-    mailer_password:   ~
+    mailer_user:       ''
+    mailer_password:   ''
 
     default_locale:       {{ default_locale }}
     locales:              [{{ enabled_locales | join(",") }}]

--- a/roles/stepup-ra/tasks/main.yml
+++ b/roles/stepup-ra/tasks/main.yml
@@ -1,40 +1,30 @@
 # Infra suff for RA
 
 - name: Put parameters.yml, samlstepupproviders(_parameters).yml and global_view_parameters.yml
-  template: src={{ item }}.j2 dest={{ component_dir_name }}/app/config/{{ item }} mode={{ component_mode_640 }} group={{ component_group }}
+  template: src={{ item }}.j2 dest={{ component_dir_name }}/config/legacy/{{ item }} mode={{ component_mode_640 }} group={{ component_group }}
   with_items:
   - parameters.yml
   - samlstepupproviders.yml
   - samlstepupproviders_parameters.yml
   - global_view_parameters.yml
 
-- name: Put images from <env>/files/stepup-app into web/images
-  copy: src={{ item }} dest={{ component_dir_name }}/web/images mode=444 group={{ component_group }}
+- name: Put images from <env>/files/stepup-app into public/images
+  copy: src={{ item }} dest={{ component_dir_name }}/public/images mode=444 group={{ component_group }}
   with_fileglob:
   - "{{inventory_dir }}/files/stepup-app/images/*"
 
-- name: Put images from <env>/files/stepup-app/second-factor into web/images/second-factor
-  copy: src={{ item }} dest={{ component_dir_name }}/web/images/second-factor mode={{ component_mode_444 }} group={{ component_group }}
+- name: Put images from <env>/files/stepup-app/second-factor into public/images/second-factor
+  copy: src={{ item }} dest={{ component_dir_name }}/public/images/second-factor mode={{ component_mode_444 }} group={{ component_group }}
   with_fileglob:
   - "{{inventory_dir }}/files/stepup-app/images/second-factor/*"
 
-- name: assets:install
-  command: php app/console assets:install --symlink --env=prod {{ debug_flag }}
+- name: Install frontend assets
+  command: yarn build
   args:
-      chdir: "{{ component_dir_name }}"
-
-- name: mopa:bootstrap:symlink:less
-  command: php app/console mopa:bootstrap:symlink:less --env=prod {{ debug_flag }}
-  args:
-      chdir: "{{ component_dir_name }}"
-
-- name: Dump Assetic Assets
-  command: php app/console assetic:dump --env=prod {{ debug_flag }}
-  args:
-      chdir: "{{ component_dir_name }}"
+    chdir: "{{ component_dir_name }}"
 
 - name: Clear and warmup cache
-  command: php app/console cache:clear --env=prod {{ debug_flag }}
+  command: php72 bin/console cache:clear --env=prod {{ debug_flag }}
   args:
     chdir: "{{ component_dir_name }}"
   when: not (develop | default(false))
@@ -48,25 +38,25 @@
 - name: Grant app write access to cache and log dirs
   file: path={{item}} group={{ component_group }} mode={{ component_mode_770 }} recurse=yes
   with_items:
-  - "{{ component_dir_name }}/app/cache"
-  - "{{ component_dir_name }}/app/logs"
+  - "{{ component_dir_name }}/var/cache"
+  - "{{ component_dir_name }}/var/logs"
   when: not (develop | default(false))
 
 # SAML SP signing certificate for authentication to the normal authentication (i.e. /authentication/metadata) IdP enspoint
 # on the Stepup-Gateway
 - name: Write SAML SP private key
-  copy: content="{{ ra_saml_sp_privatekey | vault(vault_keydir)  }}" dest={{ component_dir_name }}/app/config/sp.key owner={{ component_owner }} mode={{ component_mode_400 }}
+  copy: content="{{ ra_saml_sp_privatekey | vault(vault_keydir)  }}" dest={{ component_dir_name }}/config/keys/sp.key owner={{ component_owner }} mode={{ component_mode_400 }}
 
 - name: Write SAML SP certificate
-  copy: content="{{ ra_saml_sp_publickey }}" dest={{ component_dir_name }}/app/config/sp.crt group={{ component_group }} mode={{ component_mode_640 }}
+  copy: content="{{ ra_saml_sp_publickey }}" dest={{ component_dir_name }}/config/keys/sp.crt group={{ component_group }} mode={{ component_mode_640 }}
 
 # SAML SP signing certificate for authentication to the GSSP IdP proxy enspoint(s)
 # on the Stepup-Gateway
 - name: Write GSSP SP private key
-  copy: content="{{ ra_gssp_sp_privatekey | vault(vault_keydir)  }}" dest={{ component_dir_name }}/app/config/sp_gssp.key owner={{ component_owner }} mode={{ component_mode_400 }}
+  copy: content="{{ ra_gssp_sp_privatekey | vault(vault_keydir)  }}" dest={{ component_dir_name }}/config/keys/sp_gssp.key owner={{ component_owner }} mode={{ component_mode_400 }}
 
 - name: Write GSSP SP certificate
-  copy: content="{{ ra_gssp_sp_publickey }}" dest={{ component_dir_name }}/app/config/sp_gssp.crt group={{ component_group }} mode={{ component_mode_640 }}
+  copy: content="{{ ra_gssp_sp_publickey }}" dest={{ component_dir_name }}/config/keys/sp_gssp.crt group={{ component_group }} mode={{ component_mode_640 }}
 
 
 - name: Set stepup directory rights

--- a/roles/stepup-ra/tasks/main.yml
+++ b/roles/stepup-ra/tasks/main.yml
@@ -19,9 +19,10 @@
   - "{{inventory_dir }}/files/stepup-app/images/second-factor/*"
 
 - name: Install frontend assets
-  command: yarn build
+  command: php72 /usr/local/bin/composer frontend-install
   args:
     chdir: "{{ component_dir_name }}"
+    when: (develop | default(false))
 
 - name: Clear and warmup cache
   command: php72 bin/console cache:clear --env=prod {{ debug_flag }}

--- a/roles/stepup-ra/tasks/main.yml
+++ b/roles/stepup-ra/tasks/main.yml
@@ -18,17 +18,17 @@
   with_fileglob:
   - "{{inventory_dir }}/files/stepup-app/images/second-factor/*"
 
-- name: Install frontend assets
-  command: php72 /usr/local/bin/composer frontend-install
-  args:
-    chdir: "{{ component_dir_name }}"
-    when: (develop | default(false))
-
 - name: Clear and warmup cache
   command: php72 bin/console cache:clear --env=prod {{ debug_flag }}
   args:
     chdir: "{{ component_dir_name }}"
   when: not (develop | default(false))
+
+- name: Create a directory for keys and certificates if it does not exist
+  file:
+    path: "{{ component_dir_name }}/config/keys/"
+    state: directory
+    mode: '0755'
 
 - name: Restrict app dir to the application
   file: path={{item}} group={{ component_group }} mode="o=" recurse=yes

--- a/roles/stepup-ra/tasks/main.yml
+++ b/roles/stepup-ra/tasks/main.yml
@@ -1,12 +1,12 @@
 # Infra suff for RA
 
-- name: Put parameters.yml, samlstepupproviders(_parameters).yml and global_view_parameters.yml
-  template: src={{ item }}.j2 dest={{ component_dir_name }}/config/legacy/{{ item }} mode={{ component_mode_640 }} group={{ component_group }}
+- name: Put parameters.yaml, samlstepupproviders(_parameters).yaml and global_view_parameters.yaml
+  template: src={{ item }}.yml.j2 dest={{ component_dir_name }}/config/legacy/{{ item }}.yaml mode={{ component_mode_640 }} group={{ component_group }}
   with_items:
-  - parameters.yml
-  - samlstepupproviders.yml
-  - samlstepupproviders_parameters.yml
-  - global_view_parameters.yml
+  - parameters
+  - samlstepupproviders
+  - samlstepupproviders_parameters
+  - global_view_parameters
 
 - name: Put images from <env>/files/stepup-app into public/images
   copy: src={{ item }} dest={{ component_dir_name }}/public/images mode=444 group={{ component_group }}

--- a/roles/stepup-ra/templates/parameters.yml.j2
+++ b/roles/stepup-ra/templates/parameters.yml.j2
@@ -34,11 +34,11 @@ parameters:
     sms_otp_expiry_interval: {{ sms_otp_expiry_interval }}
     sms_maximum_otp_requests: {{ sms_maximum_otp_requests }}
 
-    saml_sp_publickey: {{ component_dir_name }}/app/config/sp.crt
-    saml_sp_privatekey: {{ component_dir_name }}/app/config/sp.key
+    saml_sp_publickey: {{ component_dir_name }}/config/keys/sp.crt
+    saml_sp_privatekey: {{ component_dir_name }}/config/keys/sp.key
 
-    saml_metadata_publickey: {{ component_dir_name }}/app/config/sp.crt
-    saml_metadata_privatekey: {{ component_dir_name }}/app/config/sp.key
+    saml_metadata_publickey: {{ component_dir_name }}/config/keys/sp.crt
+    saml_metadata_privatekey: {{ component_dir_name }}/config/keys/sp.key
 
     saml_remote_idp_entity_id: https://{{ gateway_vhost_name }}/authentication/metadata
     saml_remote_idp_sso_url: https://{{ gateway_vhost_name }}/authentication/single-sign-on

--- a/roles/stepup-ra/templates/samlstepupproviders.yml.j2
+++ b/roles/stepup-ra/templates/samlstepupproviders.yml.j2
@@ -1,6 +1,3 @@
-imports:
-    - { resource: samlstepupproviders_parameters.yml }
-
 surfnet_stepup_ra_saml_stepup_provider:
     routes:
         consume_assertion: ra_vetting_gssf_verify
@@ -11,19 +8,19 @@ surfnet_stepup_ra_saml_stepup_provider:
         {{ key }}:
             hosted:
                 service_provider:
-                    public_key: %gssp_{{ key }}_sp_publickey%
-                    private_key: %gssp_{{ key }}_sp_privatekey%
+                    public_key: '%gssp_{{ key }}_sp_publickey%'
+                    private_key: '%gssp_{{ key }}_sp_privatekey%'
                 metadata:
-                    public_key: %gssp_{{ key }}_metadata_publickey%
-                    private_key: %gssp_{{ key }}_metadata_privatekey%
+                    public_key: '%gssp_{{ key }}_metadata_publickey%'
+                    private_key: '%gssp_{{ key }}_metadata_privatekey%'
             remote:
-                entity_id: %gssp_{{ key }}_remote_entity_id%
-                sso_url: %gssp_{{ key }}_remote_sso_url%
-                certificate: %gssp_{{ key }}_remote_certificate%
+                entity_id: '%gssp_{{ key }}_remote_entity_id%'
+                sso_url: '%gssp_{{ key }}_remote_sso_url%'
+                certificate: '%gssp_{{ key }}_remote_certificate%'
             view_config:
-                title: %gssp_{{ key }}_title%
-                page_title: %gssp_{{ key }}_page_title%
-                explanation: %gssp_{{ key }}_explanation%
-                initiate: %gssp_{{ key }}_initiate%
-                gssf_id_mismatch: %gssp_{{ key }}_gssf_id_mismatch%
+                title: '%gssp_{{ key }}_title%'
+                page_title: '%gssp_{{ key }}_page_title%'
+                explanation: '%gssp_{{ key }}_explanation%'
+                initiate: '%gssp_{{ key }}_initiate%'
+                gssf_id_mismatch: '%gssp_{{ key }}_gssf_id_mismatch%'
 {% endfor %}

--- a/roles/stepup-ra/templates/samlstepupproviders_parameters.yml.j2
+++ b/roles/stepup-ra/templates/samlstepupproviders_parameters.yml.j2
@@ -5,12 +5,12 @@ parameters:
 
 {% for key, value in stepup_enabled_generic_second_factors.items() %}
     # GSSP Proxy SP used to authenticate to the Real GSSP IdP though GSSP IdP proxy in the gateway
-    gssp_{{ key }}_sp_publickey: '{{ component_dir_name }}/app/config/sp_gssp.crt'
-    gssp_{{ key }}_sp_privatekey: '{{ component_dir_name }}/app/config/sp_gssp.key'
+    gssp_{{ key }}_sp_publickey: '{{ component_dir_name }}/config/keys/sp_gssp.crt'
+    gssp_{{ key }}_sp_privatekey: '{{ component_dir_name }}/config/keys/sp_gssp.key'
 
     # Certificate used to sign metadata of the GSSP Proxy SP on the gateway
-    gssp_{{ key }}_metadata_publickey: '{{ component_dir_name }}/app/config/sp_gssp.crt'
-    gssp_{{ key }}_metadata_privatekey: '{{ component_dir_name }}/app/config/sp_gssp.key'
+    gssp_{{ key }}_metadata_publickey: '{{ component_dir_name }}/config/keys/sp_gssp.crt'
+    gssp_{{ key }}_metadata_privatekey: '{{ component_dir_name }}/config/keys/sp_gssp.key'
 
     # EntityID and SSO Location of the GSSP IdP Proxy on the Gateway
     gssp_{{ key }}_remote_entity_id: 'https://{{ gateway_vhost_name }}/gssp/{{ key }}/metadata'

--- a/roles/stepup-tiqr/tasks/main.yml
+++ b/roles/stepup-tiqr/tasks/main.yml
@@ -46,7 +46,7 @@
   file: path={{item}} group={{ component_group }} mode={{ component_mode_770 }} recurse=yes
   with_items:
   - "{{ component_dir_name }}/var/cache"
-  - "{{ component_dir_name }}/var/logs"
+  - "{{ component_dir_name }}/var/log"
   when: not (develop | default(false))
 
 - name: Write tiqr APNS certificate

--- a/roles/stepup-webauthn/tasks/main.yml
+++ b/roles/stepup-webauthn/tasks/main.yml
@@ -42,7 +42,7 @@
   file: path={{item}} group={{ component_group }} mode={{ component_mode_770 }} recurse=yes
   with_items:
   - "{{ component_dir_name }}/var/cache"
-  - "{{ component_dir_name }}/var/logs"
+  - "{{ component_dir_name }}/var/log"
   when: not (develop | default(false))
 
 - name: Write webauthn GSSP sp certificate

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -51,16 +51,17 @@ class FeatureContext implements Context
     {
         // Generate test databases
         echo "Preparing test schemas\n";
-        shell_exec("/src/Stepup-Middleware/app/console doctrine:schema:drop --env=smoketest --force");
-        shell_exec("/src/Stepup-Gateway/app/console doctrine:schema:drop --env=test --force");
-        shell_exec("/src/Stepup-Middleware/app/console doctrine:schema:create --env=smoketest");
-        shell_exec("/src/Stepup-Gateway/app/console doctrine:schema:create --env=test");
+        shell_exec("php72 /src/Stepup-Middleware/bin/console doctrine:schema:drop --env=smoketest --force");
+        shell_exec("php72 /src/Stepup-Middleware/bin/console doctrine:schema:create --env=smoketest");
+
+        shell_exec("php72 /src/Stepup-Gateway/app/console doctrine:schema:drop --env=test --force");
+        shell_exec("php72 /src/Stepup-Gateway/app/console doctrine:schema:create --env=test");
 
         echo "Replaying event stream\n";
         // Import the events.sql into middleware
         shell_exec("mysql -uroot -ppassword middleware_test < ./fixtures/events.sql");
         // Perform an event replay
-        shell_exec("/src/Stepup-Middleware/app/console middleware:event:replay --env=smoketest_event_replay --no-interaction -q");
+        shell_exec("php72 /src/Stepup-Middleware/bin/console middleware:event:replay --env=smoketest_event_replay --no-interaction -q");
 
         echo "Update the keys\n";
         // Update the `saml_entities` projection in `gateway_test`

--- a/tests/behat/features/ra_export.feature
+++ b/tests/behat/features/ra_export.feature
@@ -29,14 +29,14 @@ Feature: A RAA can export tokens registered in the selfservice portal
     Given I am logged in into the ra portal as "jane-a-raa" with a "yubikey" token
     When I visit the Tokens page
       And I click on the token export button
-    Then the response should contain "Token ID,Type,Name,Email,Institution,Document Number,Status"
-      And the response should contain "03945859,yubikey,Jane Raa,foo@bar.com,institution-a.example.com,123456,vetted"
-      And the response should contain "03945859,yubikey,Jane Ra,foo@bar.com,institution-a.example.com,123456,vetted"
+    Then the response should contain "\"Token ID\",Type,Name,Email,Institution,\"Document Number\",Status"
+    Then the response should contain "03945859,yubikey,\"Jane Raa\",foo@bar.com,institution-a.example.com,123456,vetted"
+    Then the response should contain "03945859,yubikey,\"Jane Ra\",foo@bar.com,institution-a.example.com,123456,vetted"
 
   Scenario: a user which is at least RAA for one institution can export tokens
     Given I am logged in into the ra portal as "joe-a-raa" with a "yubikey" token
     When I visit the Tokens page
       And I click on the token export button
-    Then the response should contain "Token ID,Type,Name,Email,Institution,Document Number,Status"
-      And the response should contain "03945859,yubikey,Jane Raa,foo@bar.com,institution-a.example.com,123456,vetted"
-      And the response should contain "03945859,yubikey,Jane Ra,foo@bar.com,institution-a.example.com,123456,vetted"
+    Then the response should contain "\"Token ID\",Type,Name,Email,Institution,\"Document Number\",Status"
+    Then the response should contain "03945859,yubikey,\"Jane Raa\",foo@bar.com,institution-a.example.com,123456,vetted"
+    Then the response should contain "03945859,yubikey,\"Jane Ra\",foo@bar.com,institution-a.example.com,123456,vetted"


### PR DESCRIPTION
- [ ] Shell scripts [see](https://github.com/OpenConext/Stepup-Deploy/tree/c310c7038a0daaf79764134926352f523cbeedb7/roles/stepup-middleware/templates)
- [ ] New nodejs version (Centos uses a very old version as default)
- [ ] Old php removal (This seems not to work correctly when upgrading from PHP5)
- [ ] Old default app removal [see](https://github.com/OpenConext/Stepup-Deploy/blob/da4eef5264938bb004759654731e4cb483f6ffe8/roles/app/tasks/php72-vhost.yml#L19)
