### PR TITLE
Add two demo GSSP's for integration testing

### DIFF
--- a/deploy-dev.yml
+++ b/deploy-dev.yml
@@ -1,0 +1,37 @@
+# Included from deploy.yml when dev==true
+# Demo GSSP's only for development purposes
+
+- name: Install Stepup-Demo-GSSP
+  hosts: stepup-demo-gssp
+  become: True
+  tags: stepup-demo-gssp
+
+  roles:
+    - deploy
+    - stepup-gssp-example
+
+
+  vars:
+    component_name: demo-gssp
+    component_vhost_name: "{{ demo_gssp_vhost_name }}"
+    stable_nonce: "develop"
+    needphp7: true
+    # Uses demo_gssp_idp_publickey from all.yaml
+    demo_gssp_idp_privatekey: "{{ lookup('file', inventory_dir+'/saml_cert/demo_gssp_idp.key') }}"
+
+- name: Install Stepup-Demo-GSSP 2
+  hosts: stepup-demo-gssp-2
+  become: True
+  tags: stepup-demo-gssp-2
+
+  roles:
+    - deploy
+    - stepup-gssp-example
+
+  vars:
+    component_name: demo-gssp-2
+    component_vhost_name: "{{ demo_gssp_2_vhost_name }}"
+    stable_nonce: "develop"
+    needphp7: true
+    demo_gssp_idp_publickey: "{{ demo_gssp_2_idp_publickey }}"
+    demo_gssp_idp_privatekey: "{{ lookup('file', inventory_dir+'/saml_cert/demo_gssp_2_idp.key') }}"

--- a/deploy.yml
+++ b/deploy.yml
@@ -142,3 +142,33 @@
       component_vhost_name: "{{ webauthn_vhost_name }}"
       component_dir_name: "/opt/stepup/{{ component_tarball_name | basename | regex_replace('^(.*)\\.tar\\.bz2$', '\\1') }}"
       stable_nonce: "{{ component_tarball_name | basename | regex_replace('^.*-(.{8}).{32}\\.tar\\.bz2$', '\\1') }}"
+
+
+# Demo GSSP's only for development purposes
+- name: Install Stepup-Demo-GSSP
+  hosts: stepup-demo-gssp
+  become: True
+  tags: stepup-demo-gssp
+
+  roles:
+    - stepup-gssp-example
+    - deploy
+
+  vars:
+    component_name: demo-gssp
+    component_vhost_name: "{{ demo_gssp_vhost_name }}"
+    stable_nonce: "develop"
+
+- name: Install Stepup-Demo-GSSP 2
+  hosts: stepup-demo-gssp-2
+  become: True
+  tags: stepup-demo-gssp-2
+
+  roles:
+    - stepup-gssp-example
+    - deploy
+
+  vars:
+    component_name: demo-gssp-2
+    component_vhost_name: "{{ demo_gssp_2_vhost_name }}"
+    stable_nonce: "develop"

--- a/deploy.yml
+++ b/deploy.yml
@@ -143,32 +143,5 @@
       component_dir_name: "/opt/stepup/{{ component_tarball_name | basename | regex_replace('^(.*)\\.tar\\.bz2$', '\\1') }}"
       stable_nonce: "{{ component_tarball_name | basename | regex_replace('^.*-(.{8}).{32}\\.tar\\.bz2$', '\\1') }}"
 
-
-# Demo GSSP's only for development purposes
-- name: Install Stepup-Demo-GSSP
-  hosts: stepup-demo-gssp
-  become: True
-  tags: stepup-demo-gssp
-
-  roles:
-    - stepup-gssp-example
-    - deploy
-
-  vars:
-    component_name: demo-gssp
-    component_vhost_name: "{{ demo_gssp_vhost_name }}"
-    stable_nonce: "develop"
-
-- name: Install Stepup-Demo-GSSP 2
-  hosts: stepup-demo-gssp-2
-  become: True
-  tags: stepup-demo-gssp-2
-
-  roles:
-    - stepup-gssp-example
-    - deploy
-
-  vars:
-    component_name: demo-gssp-2
-    component_vhost_name: "{{ demo_gssp_2_vhost_name }}"
-    stable_nonce: "develop"
+- include: deploy-dev.yml
+  when: develop | default(false)

--- a/environments/template/environment.conf
+++ b/environments/template/environment.conf
@@ -85,6 +85,10 @@ SAML_CERTS=(
 
   # This is the SAML signing certificate of the Webauthn GSSP IdP
   "webauthn_idp:/CN=RA Tiqr IdP/O=${SAML_O}"
+
+  # This are the SAML signing certificate of the Demo GSSP IdPs
+  "demo_gssp_idp:/CN=Demo GSSP IdP/O=${SAML_O}"
+  "demo_gssp_2_idp:/CN=Demo GSSP 2 IdP/O=${SAML_O}"
 )
 
 
@@ -117,6 +121,9 @@ SSL_CERTS=(
   "webauthn:/CN=webauthn.${SSL_DOMAIN}/O=${SSL_O}/C=${SSL_C}"
   "keyserver:/CN=keyserver.${SSL_DOMAIN}/O=${SSL_O}/C=${SSL_C}"
   "simplesaml:/CN=simplesaml.${SSL_DOMAIN}/O=${SSL_O}/C=${SSL_C}"
+
+  "demo-gssp:/CN=demo-gssp.${SSL_DOMAIN}/O=${SSL_O}/C=${SSL_C}"
+  "demo-gssp-2:/CN=demo-gssp-2.${SSL_DOMAIN}/O=${SSL_O}/C=${SSL_C}"
 )
 
 ### SSH keys ###

--- a/environments/template/group_vars/all.yml
+++ b/environments/template/group_vars/all.yml
@@ -51,7 +51,11 @@ gateway_vhost_name: gateway.stepup.example.com
 tiqr_vhost_name: tiqr.stepup.example.com
 webauthn_vhost_name: webauthn.stepup.example.com
 keyserver_vhost_name: keyserver.stepup.example.com
+
 ssp_vhost_name: ssp.stepup.example.com # Used by the "dev" role only
+demo_gssp_vhost_name: demo-gssp.stepup.example.com # Used by the "dev" role only
+demo_gssp_2_vhost_name: demo-gssp-2.stepup.example.com # Used by the "dev" role only
+
 
 # Domain for the locale cookie that is set by gateway, selfservice and ra and that is used to share the
 # user's locale preference with other (stepup) components

--- a/environments/template/group_vars/all.yml
+++ b/environments/template/group_vars/all.yml
@@ -52,10 +52,6 @@ tiqr_vhost_name: tiqr.stepup.example.com
 webauthn_vhost_name: webauthn.stepup.example.com
 keyserver_vhost_name: keyserver.stepup.example.com
 
-ssp_vhost_name: ssp.stepup.example.com # Used by the "dev" role only
-demo_gssp_vhost_name: demo-gssp.stepup.example.com # Used by the "dev" role only
-demo_gssp_2_vhost_name: demo-gssp-2.stepup.example.com # Used by the "dev" role only
-
 
 # Domain for the locale cookie that is set by gateway, selfservice and ra and that is used to share the
 # user's locale preference with other (stepup) components
@@ -102,12 +98,11 @@ stepup_enabled_factors: sms, yubikey, u2f
 # Tip: search for "example_gssp" to see where you need to make changes.
 # TODO: Select GSSPs to enable, and specify the LoA level to assign to the GSSP
 # Available LoA levels: 2 and 3
+# Note you cannot use a dash ('-') in a GSSP name, use an underscore ("_") instead
 stepup_enabled_generic_second_factors:
   tiqr:
     loa: 2
-# example_gssp:
-#   loa: 2
-
+# Note: for the Stepup-VM this is overridden in dev.yml
 
 # Set the addres(ses) of the loadbalancer(s)
 # These are the IP addresses for which the X-Forwarded-For HTTP header is honoured.
@@ -205,11 +200,6 @@ tiqr_idp_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/tiqr_idp.crt') 
 # Private key in stepup-webauthn.yml
 # Format: PEM X.509 certificate
 webauthn_idp_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/webauthn_idp.crt') }}"
-
-
-# Public SAML signing key of the "example_gssp" GSSP IDP
-# Format: PEM X.509 certificate
-#gssp_example_idp_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/gssp_example_idp.crt') }}"
 
 
 # Database tables and users for Stepup applications, keyserver

--- a/environments/template/group_vars/dev.yml
+++ b/environments/template/group_vars/dev.yml
@@ -1,6 +1,30 @@
-# Use mailcatcher as smarthost
-# Note: For production this would be set in app.yml group_var
+# vhost names for simple saml test idp and sp
+# For production these would be set in app.yml group_var
+ssp_vhost_name: ssp.stepup.example.com
+demo_gssp_vhost_name: demo-gssp.stepup.example.com
+demo_gssp_2_vhost_name: demo-gssp-2.stepup.example.com
 
+
+# TLS server certificates for the ssp en demo_gssp vhosts
+# For production these would be set in app.yml group_var
+
+# Format: PEM Certificate (chain)
+# Order: SSL Server certificate followed by intermediate certificate(s) in chain order.
+# Do not include root CA certificate
+proxy_demo_gssp_certificate: "{{ lookup('file', inventory_dir+'/ssl_cert/demo-gssp.crt') }}"
+proxy_demo_gssp_2_certificate: "{{ lookup('file', inventory_dir+'/ssl_cert/demo-gssp-2.crt') }}"
+
+# Format: PEM RSA PRIVATE KEY
+proxy_demo_gssp_key: "{{ lookup('file', inventory_dir+'/ssl_cert/demo-gssp.key') }}"
+proxy_demo_gssp_2_key: "{{ lookup('file', inventory_dir+'/ssl_cert/demo-gssp-2.key') }}"
+
+
+
+# Public SAML signing keys of the demo_gssp's
+demo_gssp_idp_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/demo_gssp_idp.crt') }}"
+demo_gssp_2_idp_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/demo_gssp_2_idp.crt') }}"
+
+# Use mailcatcher as smarthost
 # Hostname of sendmail SMTP smarthost (optional)
 # Square brackets disable DNS lookup
 sendmail_smarthost: [localhost]
@@ -21,15 +45,166 @@ ssp_sp2_privatekey: "{{ lookup('file', inventory_dir+'/saml_cert/simplesaml_sp2.
 ssp_sp2_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/simplesaml_sp2.crt') }}"
 
 # Enabled development second factors
+# Overrides definition in all.yml
 stepup_enabled_generic_second_factors:
   tiqr:
     loa: 2
-  demo-gssp:
+  demo_gssp:
     loa: 2
-  demo-gssp-2:
-    loa: 2
+  demo_gssp_2:
+    loa: 3
 
 # Skip the prove token possession step
 skip_prove_possession_second_factors:
   - gssp-2
 
+
+##############################################################################
+# demo_gssp and demo_gssp_2 configuration
+# For production these would be set in stepup-gateway.yml group_var
+
+# Entity ID of the remote "example_gssp" Idp
+gateway_demo_gssp_remote_entity_id: 'https://{{ demo_gssp_vhost_name }}/saml/metadata'
+# SingleSingOn Location of the remote "example_gssp" IdP
+gateway_demo_gssp_remote_sso_url: 'https://{{ demo_gssp_vhost_name }}/saml/sso'
+# SAML signing certificate of the "example_gssp" IdP
+# Format: Base64 encoded X.509 certificate without PEM headers
+gateway_demo_gssp_remote_certificate: "{{ demo_gssp_idp_publickey | depem }}"
+
+#Logo and description for the WAYG (token selection) screen on the gateway
+#Add the new logo to files/stepup-app/images to make it available on the server
+gateway_demo_gssp_logo: "/images/demo-gssp.png"
+gateway_demo_gssp_title:
+  en_GB: "Demo GSSP"
+  nl_NL: "Demo GSSP"
+
+# Entity ID of the remote "example_gssp" Idp
+gateway_demo_gssp_2_remote_entity_id: 'https://{{ demo_gssp_vhost_name }}/saml/metadata'
+# SingleSingOn Location of the remote "example_gssp" IdP
+gateway_demo_gssp_2_remote_sso_url: 'https://{{ demo_gssp_vhost_name }}/saml/sso'
+# SAML signing certificate of the "example_gssp" IdP
+# Format: Base64 encoded X.509 certificate without PEM headers
+gateway_demo_gssp_2_remote_certificate: "{{ demo_gssp_idp_publickey | depem }}"
+
+#Logo and description for the WAYG (token selection) screen on the gateway
+#Add the new logo to files/stepup-app/images to make it available on the server
+gateway_demo_gssp_2_logo: "/images/demo-gssp.png"
+gateway_demo_gssp_2_title:
+  en_GB: "Demo GSSP"
+  nl_NL: "Demo GSSP"
+
+
+##############################################################################
+# demo_gssp and demo_gssp_2 configuration
+# For production these would be set in stepup-selfservice.yml group_var
+
+# Logo on the token selection page
+#Add the new logo to files/stepup-app/images to make it available on the server
+ss_gssp_demo_gssp_logo: /images/demo-gssp.png
+
+# Links to download the app for Android or IOS. See "ss_gssp_demo_gssp_description" for how these are used
+ss_gssp_demo_gssp_app_android_url: https://example.com/demo-gssp-android
+ss_gssp_demo_gssp_app_ios_url: https://example.com/demo-gssp-ios
+
+# Translations
+ss_gssp_demo_gssp_alt:
+    en_GB: 'demo_gssp'
+    nl_NL: 'demo_gssp'
+ss_gssp_demo_gssp_title:
+    en_GB: 'Demo GSSP'
+    nl_NL: 'Demonstratie GSSP'
+ss_gssp_demo_gssp_description:
+    en_GB: 'Log in with the "Demo GSSP" app. For all smartphones with %%ios_link_start%%Apple iOS%%ios_link_end%% or %%android_link_start%%Android%%android_link_end%%.'
+    nl_NL: 'Log in met de "Demonstratie GSSP" app op je smartphone. Geschikt voor smartphones met %%ios_link_start%%Apple iOS%%ios_link_end%% of %%android_link_start%%Android%%android_link_end%%.'
+ss_gssp_demo_gssp_button_use:
+    en_GB: 'Select'
+    nl_NL: 'Selecteer'
+ss_gssp_demo_gssp_initiate_title:
+    en_GB: 'Register with the Demo GSSP'
+    nl_NL: 'Registreren bij de demonstratie GSSP'
+ss_gssp_demo_gssp_initiate_button:
+    en_GB: 'Register with the Demo GSSP'
+    nl_NL: 'Registreer bij de demonstratie GSSP'
+ss_gssp_demo_gssp_explanation:
+    en_GB: 'Click the button below to register with the Demo GSSP.'
+    nl_NL: 'Klik op de knop hieronder om je bij de demonstratie GSSP te registreren.'
+ss_gssp_demo_gssp_authn_failed:
+    en_GB: 'Registration with the Demo GSSP has failed. Please try again.'
+    nl_NL: 'Registratie bij demonstratie GSSP is mislukt. Probeer het nogmaals.'
+ss_gssp_demo_gssp_pop_failed:
+    en_GB: 'Registration of your token failed. Please try again.'
+    nl_NL: 'De registratie van uw token is mislukt. Probeer het nogmaals.'
+
+# Logo on the token selection page
+#Add the new logo to files/stepup-app/images to make it available on the server
+ss_gssp_demo_gssp_2_logo: /images/demo-gssp.png
+
+# Links to download the app for Android or IOS. See "ss_gssp_demo_gssp_description" for how these are used
+ss_gssp_demo_gssp_2_app_android_url: https://example.com/demo-gssp-2-android
+ss_gssp_demo_gssp_2_app_ios_url: https://example.com/demo-gssp-2-ios
+
+# Translations
+ss_gssp_demo_gssp_2_alt:
+  en_GB: 'demo_gssp_2'
+  nl_NL: 'demo_gssp_2'
+ss_gssp_demo_gssp_2_title:
+  en_GB: 'Demo GSSP 2'
+  nl_NL: 'Demonstratie GSSP 2'
+ss_gssp_demo_gssp_2_description:
+  en_GB: 'Log in with the "Demo GSSP 2" app. For all smartphones with %%ios_link_start%%Apple iOS%%ios_link_end%% or %%android_link_start%%Android%%android_link_end%%.'
+  nl_NL: 'Log in met de "Demonstratie GSSP 2" app op je smartphone. Geschikt voor smartphones met %%ios_link_start%%Apple iOS%%ios_link_end%% of %%android_link_start%%Android%%android_link_end%%.'
+ss_gssp_demo_gssp_2_button_use:
+  en_GB: 'Select'
+  nl_NL: 'Selecteer'
+ss_gssp_demo_gssp_2_initiate_title:
+  en_GB: 'Register with the Demo GSSP 2'
+  nl_NL: 'Registreren bij de demonstratie GSSP 2'
+ss_gssp_demo_gssp_2_initiate_button:
+  en_GB: 'Register with the Demo GSSP-2'
+  nl_NL: 'Registreer bij de demonstratie GSSP-2'
+ss_gssp_demo_gssp_2_explanation:
+  en_GB: 'Click the button below to register with the Demo GSSP 2'
+  nl_NL: 'Klik op de knop hieronder om je bij de demonstratie GSSP 2 te registreren'
+ss_gssp_demo_gssp_2_authn_failed:
+  en_GB: 'Registration with the Demo GSSP 2 has failed. Please try again.'
+  nl_NL: 'Registratie bij demonstratie GSSP 2 is mislukt. Probeer het nogmaals.'
+ss_gssp_demo_gssp_2_pop_failed:
+  en_GB: 'Registration of your token failed. Please try again.'
+  nl_NL: 'De registratie van uw token is mislukt. Probeer het nogmaals.'
+
+
+##############################################################################
+# demo_gssp and demo_gssp_2 configuration
+# For production these would be set in stepup-ra.yml group_var
+
+ra_gssp_demo_gssp_title:
+  en_GB: 'Example GSSP'
+  nl_NL: 'Voorbeeld GSSP'
+ra_gssp_demo_gssp_page_title:
+  en_GB: 'Verify with Example GSSP'
+  nl_NL: 'Verifiëren met de voorbeeld GSSP'
+ra_gssp_demo_gssp_explanation:
+  en_GB: 'Click the button below to verify the registrant can authenticate with the "Example GSSP" token he or she registered with in the Self-Service application.'
+  nl_NL: 'Klik de knop hieronder om te verifiëren dat de registrant het Tiqr-account bezit dat hij of zij gebruikt heeft in de Self-Service-applicatie.'
+ra_gssp_demo_gssp_initiate:
+  en_GB: 'Verify with Example GSSP'
+  nl_NL: 'Verifiëren met de voorbeeld GSSP'
+ra_gssp_demo_gssp_gssf_id_mismatch:
+  en_GB: "The \"example GSSP\" responded with an ID that doesn't match the ID that the registrant registered with using the Self-Service application."
+  nl_NL: 'De "voorbeel GSSP" heeft een ID teruggegeven dat niet overeenkomt met het ID dat de registrant heeft geregistreerd in de Self-Service-applicatie.'
+
+ra_gssp_demo_gssp_2_title:
+  en_GB: 'Example GSSP'
+  nl_NL: 'Voorbeeld GSSP'
+ra_gssp_demo_gssp_2_page_title:
+  en_GB: 'Verify with Example GSSP'
+  nl_NL: 'Verifiëren met de voorbeeld GSSP'
+ra_gssp_demo_gssp_2_explanation:
+  en_GB: 'Click the button below to verify the registrant can authenticate with the "Example GSSP" token he or she registered with in the Self-Service application.'
+  nl_NL: 'Klik de knop hieronder om te verifiëren dat de registrant het Tiqr-account bezit dat hij of zij gebruikt heeft in de Self-Service-applicatie.'
+ra_gssp_demo_gssp_2_initiate:
+  en_GB: 'Verify with Example GSSP'
+  nl_NL: 'Verifiëren met de voorbeeld GSSP'
+ra_gssp_demo_gssp_2_gssf_id_mismatch:
+  en_GB: "The \"example GSSP\" responded with an ID that doesn't match the ID that the registrant registered with using the Self-Service application."
+  nl_NL: 'De "voorbeel GSSP" heeft een ID teruggegeven dat niet overeenkomt met het ID dat de registrant heeft geregistreerd in de Self-Service-applicatie.'

--- a/environments/template/group_vars/dev.yml
+++ b/environments/template/group_vars/dev.yml
@@ -19,3 +19,17 @@ ssp_sp_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/simplesaml_sp.crt
 
 ssp_sp2_privatekey: "{{ lookup('file', inventory_dir+'/saml_cert/simplesaml_sp2.key') }}"
 ssp_sp2_publickey: "{{ lookup('file', inventory_dir+'/saml_cert/simplesaml_sp2.crt') }}"
+
+# Enabled development second factors
+stepup_enabled_generic_second_factors:
+  tiqr:
+    loa: 2
+  demo-gssp:
+    loa: 2
+  demo-gssp-2:
+    loa: 2
+
+# Skip the prove token possession step
+skip_prove_possession_second_factors:
+  - gssp-2
+

--- a/roles/app/tasks/main.yml
+++ b/roles/app/tasks/main.yml
@@ -31,8 +31,10 @@
       - mysql
       - bzip2
       - nginx
-      - nodejs
-      - nodejs-less.noarch
+
+      - nodejs # CentOS 7 nodejs = 6.11.1
+      - nodejs-less.noarch # nodejs less module required for assetic:dump by SS, RA and GW <= release 17
+
       - sendmail
       - sendmail-cf
       # PHP 5.6 from remi-php56 repo. These override the centos base php versions

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -1,0 +1,1 @@
+needphp7: False

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -122,19 +122,24 @@
     # - "--ignore-platform-reqs"
     # - "--optimize-autoloader"
 
+    # Set php cli command based on whether the component requires php7
+    - set_fact:
+        php_cli: "{{ needphp7 | ternary('php72', 'php') }}"
+        symfony4: "{{ component_name in ['tiqr', 'webauthn', 'demo-gssp', 'demo-gssp-2'] }}"
+
     # If composer install fails:
     # - Remove the non .dist versions of the configuration in /app/config
     - name: DEVELOP - Composer install
-      shell: export COMPOSER_CACHE_DIR=/vagrant/composer_cache && /usr/local/bin/composer install --no-interaction --working-dir={{ component_dir_name }}
+      shell: "export COMPOSER_CACHE_DIR=/vagrant/composer_cache && {{ php_cli }} /usr/local/bin/composer install --no-interaction --working-dir={{ component_dir_name }}"
 
     # Rebuild cache
     - name: DEVELOP - Clear cache (/app/console)
-      shell: php {{ component_dir_name }}/app/console cache:clear --env=prod --no-warmup
-      when: component_name != "tiqr"
+      shell: "{{ php_cli }} {{ component_dir_name }}/app/console cache:clear --env=prod --no-warmup"
+      when: not symfony4
 
     - name: DEVELOP - Clear cache (/bin/console)
-      shell: php {{ component_dir_name }}/bin/console cache:clear --env=prod --no-warmup
-      when: component_name == "tiqr"
+      shell: "{{ php_cli }} {{ component_dir_name }}/bin/console cache:clear --env=prod --no-warmup"
+      when: symfony4
 
     - name: DEVELOP - Set debug, mode, owner and group for develop
       set_fact:
@@ -160,10 +165,10 @@
 
     - name: DEVELOP - put app_dev.php
       copy: remote_src=true src={{ component_dir_name }}/app_dev.php.dist dest={{ component_dir_name }}/web/app_dev.php
-      when: component_name != "tiqr" and component_name != "keyserver"
+      when: component_name not in ["tiqr", "keyserver", "demo-gssp", "demo-gssp-2"]
 
     - name: DEVELOP - put app_test.php
       copy: remote_src=true src={{ component_dir_name }}/app_test.php.dist dest={{ component_dir_name }}/web/app_test.php
-      when: component_name != "tiqr" and component_name != "keyserver"
+      when: component_name not in ["tiqr", "keyserver", "demo-gssp", "demo-gssp-2"]
 
   when: develop | default(false)

--- a/roles/dev/tasks/main.yml
+++ b/roles/dev/tasks/main.yml
@@ -38,12 +38,21 @@
 - name: Put /etc/rc.d/rc.local
   copy: src=rc.local dest=/etc/rc.d/rc.local mode=550
 
-## Yarn ##
+## Nodejs / NPM / Yarn stack ##
 
-# Required for dev install of Symfony 3 components
+# Needed to build the frontend assets in development
+- name: Add Nodesource repositories for Node.js
+  yum:
+    name: "https://rpm.nodesource.com/pub_12.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
+    state: present
 
-- name: Install yarn
-  shell: npm install -g yarn
+- name: Ensure Node.js and npm are installed
+  yum:
+    name:
+      - "nodejs-12*"
+    state: latest
+    enablerepo: nodesource
+
 
 ## XDebug ##
 

--- a/roles/dev/tasks/main.yml
+++ b/roles/dev/tasks/main.yml
@@ -38,20 +38,33 @@
 - name: Put /etc/rc.d/rc.local
   copy: src=rc.local dest=/etc/rc.d/rc.local mode=550
 
+
 ## Nodejs / NPM / Yarn stack ##
 
-# Needed to build the frontend assets in development
-- name: Add Nodesource repositories for Node.js
-  yum:
-    name: "https://rpm.nodesource.com/pub_12.x/el/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/nodesource-release-el{{ ansible_distribution_major_version }}-1.noarch.rpm"
-    state: present
+# Note that that the centos 7 nodejs (version 6), nmp and the nodjejs-less module are installed for
+# the Stepup components that still use Assetic. Currently (Release 17) these are: Stepup-Gateway, Stepup-Selfservice
+# and Stepup-RA.
 
-- name: Ensure Node.js and npm are installed
-  yum:
-    name:
-      - "nodejs-12*"
-    state: latest
-    enablerepo: nodesource
+# Newer components require a newer nodejs at build time only. We use nvm to install newer node versions and to switch to
+# a newer node version
+# nvm is installed as root. Add "source /root/.bashrc" to the shell command to enable nvm, then use "nvm use <version>"
+# to enable one of the installed versions.
+
+- name: "Install node version manager (nvm)"
+  shell:
+    cmd: "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash"
+    warn: false # disable curl warning
+    creates: /root/.nvm/
+
+
+# stepup-example-gssp requires node 12 with yarn
+- name: "Install node version 12"
+  shell:
+    cmd: "source /root/.bashrc && nvm install 12"
+
+- name: "Install npm module 'yarn'"
+  shell:
+    cmd: "source /root/.bashrc && nvm use 12 && npm install --global yarn"
 
 
 ## XDebug ##

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -53,3 +53,20 @@
     proxy_certificate: "{{ proxy_keyserver_certificate }}"
     proxy_key: "{{ proxy_keyserver_key }}"
   when: "inventory_hostname in groups['stepup-keyserver']"
+
+
+- include: proxy.yml
+  vars:
+    vhost_name: "{{ demo_gssp_vhost_name }}"
+    component_name: demogssp
+    proxy_certificate: "{{ proxy_tiqr_certificate }}"
+    proxy_key: "{{ proxy_tiqr_key }}"
+  when: "inventory_hostname in groups['stepup-demo-gssp']"
+
+- include: proxy.yml
+  vars:
+    vhost_name: "{{ demo_gssp_2_vhost_name }}"
+    component_name: demogssp2
+    proxy_certificate: "{{ proxy_tiqr_certificate }}"
+    proxy_key: "{{ proxy_tiqr_key }}"
+  when: "inventory_hostname in groups['stepup-demo-gssp-2']"

--- a/roles/proxy/tasks/main.yml
+++ b/roles/proxy/tasks/main.yml
@@ -58,15 +58,15 @@
 - include: proxy.yml
   vars:
     vhost_name: "{{ demo_gssp_vhost_name }}"
-    component_name: demogssp
-    proxy_certificate: "{{ proxy_tiqr_certificate }}"
-    proxy_key: "{{ proxy_tiqr_key }}"
+    component_name: demo-gssp
+    proxy_certificate: "{{ proxy_demo_gssp_certificate }}"
+    proxy_key: "{{ proxy_demo_gssp_key }}"
   when: "inventory_hostname in groups['stepup-demo-gssp']"
 
 - include: proxy.yml
   vars:
     vhost_name: "{{ demo_gssp_2_vhost_name }}"
-    component_name: demogssp2
-    proxy_certificate: "{{ proxy_tiqr_certificate }}"
-    proxy_key: "{{ proxy_tiqr_key }}"
+    component_name: demo-gssp-2
+    proxy_certificate: "{{ proxy_demo_gssp_2_certificate }}"
+    proxy_key: "{{ proxy_demo_gssp_2_key }}"
   when: "inventory_hostname in groups['stepup-demo-gssp-2']"

--- a/roles/stepup-gssp-example/tasks/main.yml
+++ b/roles/stepup-gssp-example/tasks/main.yml
@@ -4,15 +4,37 @@
   fail: msg="You should never install the demo gssp in production"
   when: not (develop | default(false))
 
+# nodejs 12 and yarn were installed by the dev role using nvm
+- name: Run yarn encore dev using nodejs 12
+  shell:
+    cmd: source /root/.bashrc && nvm use 12 && yarn encore dev
+    chdir: "{{ component_dir_name }}"
 
 - name: Copy .env file
   copy: remote_src=True src={{ component_dir_name }}/.env.ci dest={{ component_dir_name }}/.env
-
 
 - name: Put parameters.yml
   template: src={{ item }}.j2 dest={{ component_dir_name }}/config/packages/{{ item }} mode=666
   with_items:
     - parameters.yaml
+
+- name: Create app_dev.php
+  file:
+    src: "{{ component_dir_name }}/public/index.php"
+    dest: "{{ component_dir_name }}/public/app_dev.php"
+    state: link
+
+# This is the certificate of the SP that the Demo GSSP trusts for validating SAML AuthnRequests form the Stepup-Gateway
+- name: Write Demo GSSP SP certificate
+  copy: content="{{ gateway_gssp_sp_publickey }}" dest={{ component_dir_name }}/config/sp.pem group={{ component_group }} mode={{ component_mode_640 }}
+
+
+# These are the certificate and key that the Demo GSSP uses for signing SAML Responses for the Stepup-Gateway
+- name: Write Demo GSSP idp certificate
+  copy: content="{{ demo_gssp_idp_publickey }}" dest={{ component_dir_name }}/config/idp.pem group={{ component_group }} mode={{ component_mode_640 }}
+
+- name: Write Demo GSSP idp private key
+  copy: content="{{ demo_gssp_idp_privatekey | vault(vault_keydir) }}" dest={{ component_dir_name }}/config/idp.key owner={{ component_owner }} mode={{ component_mode_400 }}
 
 
 # Finish

--- a/roles/stepup-gssp-example/tasks/main.yml
+++ b/roles/stepup-gssp-example/tasks/main.yml
@@ -1,0 +1,20 @@
+# Install demo gssp component
+
+- name: Exit if not develop
+  fail: msg="You should never install the demo gssp in production"
+  when: not (develop | default(false))
+
+
+- name: Copy .env file
+  copy: remote_src=True src={{ component_dir_name }}/.env.ci dest={{ component_dir_name }}/.env
+
+
+- name: Put parameters.yml
+  template: src={{ item }}.j2 dest={{ component_dir_name }}/config/packages/{{ item }} mode=666
+  with_items:
+    - parameters.yaml
+
+
+# Finish
+- name: Activate component
+  file: src={{ component_dir_name }} dest=/opt/www/{{ component_vhost_name }} state=link

--- a/roles/stepup-gssp-example/templates/parameters.yaml.j2
+++ b/roles/stepup-gssp-example/templates/parameters.yaml.j2
@@ -1,0 +1,14 @@
+# This file is a "template" of what your parameters.yml file should look like
+# Set parameters here that may be different on each deployment target of the app, e.g. development, staging, production.
+# https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
+
+parameters:
+    saml_idp_publickey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
+    saml_idp_privatekey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'
+    saml_metadata_publickey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
+    saml_metadata_privatekey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'
+    saml_remote_sp_entity_id: 'https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/metadata.php/default-sp'
+    saml_remote_sp_sso_url: '"https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/saml2-acs.php/default-sp"'
+    saml_remote_sp_certificate: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-gssp-bundle/src/Resources/keys/pieter.aai.surfnet.nl.pem'
+    saml_remote_sp_acs: 'https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/saml2-acs.php/default-sp'
+

--- a/roles/stepup-gssp-example/templates/parameters.yaml.j2
+++ b/roles/stepup-gssp-example/templates/parameters.yaml.j2
@@ -3,12 +3,12 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
 parameters:
-    saml_idp_publickey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
-    saml_idp_privatekey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'
-    saml_metadata_publickey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_publickey.cer'
-    saml_metadata_privatekey: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-saml-bundle/src/Resources/keys/development_privatekey.pem'
-    saml_remote_sp_entity_id: 'https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/metadata.php/default-sp'
-    saml_remote_sp_sso_url: '"https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/saml2-acs.php/default-sp"'
-    saml_remote_sp_certificate: '%kernel.root_dir%/../../../../vendor/surfnet/stepup-gssp-bundle/src/Resources/keys/pieter.aai.surfnet.nl.pem'
-    saml_remote_sp_acs: 'https://pieter.aai.surfnet.nl/simplesamlphp/module.php/saml/sp/saml2-acs.php/default-sp'
+    saml_idp_publickey: '{{ component_dir_name }}/config/idp.pem'
+    saml_idp_privatekey: '{{ component_dir_name }}/config/idp.key'
+    saml_metadata_publickey: '{{ component_dir_name }}/config/idp.pem'
+    saml_metadata_privatekey: '{{ component_dir_name }}/config/idp.key'
+
+    saml_remote_sp_entity_id: 'https://{{ gateway_vhost_name }}/gssp/{{ component_name | replace('-', '_') }}/metadata'
+    saml_remote_sp_certificate: '{{ component_dir_name }}/config/sp.pem'
+    saml_remote_sp_acs: 'https://{{ gateway_vhost_name }}/gssp/{{ component_name | replace('-', '_') }}/consume-assertion'
 


### PR DESCRIPTION
This is done only for development so the integration could be tested.
The production GSSP's need to be internet facing to do validation, this
prevents automatic testing. So in order to have some decent integration
tests this is needed.