### PR TITLE
Add optional proof of possession test

### DIFF
--- a/tests/behat/features/bootstrap/RaContext.php
+++ b/tests/behat/features/bootstrap/RaContext.php
@@ -76,6 +76,19 @@ class RaContext implements Context
     }
 
     /**
+     * @Given /^I vet the last added second factor, not requiring proof of possession$/
+     */
+    public function iVetTheLastAddedSecondFactorNoProofOfPossession()
+    {
+        $secondFactorId = $this->selfServiceContext->getVerifiedSecondFactorId();
+        $activationCode = $this->selfServiceContext->getActivationCode();
+
+        $this->findsTokenForActivation($activationCode);
+        $this->adminVerifiesUserIdentity($secondFactorId);
+        $this->vettingProcessIsCompleted($secondFactorId);
+    }
+
+    /**
      * @Given /^I vet a second factor with id "([^"]*)" and with activation code "([^"]*)"$/
      */
     public function iVetASecondFactor($secondFactorId, $activationCode)

--- a/tests/behat/features/bootstrap/SelfServiceContext.php
+++ b/tests/behat/features/bootstrap/SelfServiceContext.php
@@ -149,6 +149,41 @@ class SelfServiceContext implements Context
     }
 
     /**
+     * @When /^I register a new demogssp token$/
+     */
+    public function iRegisterANewDemogsspToken()
+    {
+        // Click 'add token' on the overview page
+        $this->minkContext->clickLink('Add token');
+
+        $this->minkContext->assertPageAddress('/registration/select-token');
+
+        // Select the dummy second factor type
+        $this->minkContext->getSession()
+            ->getPage()
+            ->find('css', '[href="/registration/gssf/demogssp/initiate"]')->click();
+
+        $this->minkContext->assertPageAddress('/registration/gssf/demogssp/initiate');
+
+        // Start registration
+        $this->minkContext->assertPageContainsText('Register with Demogssp');
+        $this->minkContext->pressButton('Register with Demogssp');
+
+        // Register onthe dummy application
+        $this->minkContext->assertPageAddress('http://localhost:1234/app_dev.php/registration');
+        $this->minkContext->pressButton('Register user');
+
+        // Pass trough GSSP return action
+        $this->minkContext->pressButton('Submit');
+
+        // Pass trough gateway
+        $this->authContext->passTroughGatewayProxyAssertionConsumerService();
+
+        $this->minkContext->assertPageContainsText('Verify your e-mail');
+        $this->minkContext->assertPageContainsText('Check your inbox');
+    }
+
+    /**
      * @When I verify my e-mail address
      */
     public function verifyEmailAddress()

--- a/tests/behat/features/ra_optional_prove_possession_step.feature
+++ b/tests/behat/features/ra_optional_prove_possession_step.feature
@@ -1,0 +1,18 @@
+Feature: A RA vets tokens tokens registered in the selfservice portal
+  In order to manage tokens
+  As a RA
+  I must be able to manage second factor tokens in RA
+
+  Scenario: Provision an institution and a user
+    Given institution "institution-a.example.com" can "use_ra" from institution "institution-a.example.com"
+      And institution "institution-a.example.com" can "select_raa" from institution "institution-a.example.com"
+      And a user "Janis Bower" identified by "urn:collab:person:institution-a.example.com:janis-a-ra" from institution "institution-a.example.com"
+      And the user "urn:collab:person:institution-a.example.com:janis-a-ra" has a vetted "yubikey"
+      And the user "urn:collab:person:institution-a.example.com:janis-a-ra" has the role "ra" for institution "institution-a.example.com"
+
+  Scenario: Demo GSSP does not require proof of possession
+    Given I am logged in into the selfservice portal as "joe-a1"
+    And I register a new demogssp2 token
+    And I verify my e-mail address
+    When I am logged in into the ra portal as "jane-a-ra" with a "yubikey" token
+    Then I vet the last added second factor, not requiring proof of possession


### PR DESCRIPTION
The demo gssp does not require a secondary proof of posession step when
the user visits the RA for vetting. This feature verifies just that.

https://www.pivotaltracker.com/story/show/174114876