### PR TITLE
Set explanation in GSSP view config

### DIFF
--- a/roles/stepup-selfservice/templates/samlstepupproviders.yml.j2
+++ b/roles/stepup-selfservice/templates/samlstepupproviders.yml.j2
@@ -29,7 +29,7 @@ surfnet_stepup_self_service_saml_stepup_provider:
                 button_use: "%gssp_{{ key }}_button_use%"
                 initiate_title: "%gssp_{{ key }}_initiate_title%"
                 initiate_button: "%gssp_{{ key }}_initiate_button%"
-                explanation: "%gssp_{{ key }}_initiate_title%"
+                explanation: "%gssp_{{ key }}_explanation%"
                 authn_failed: "%gssp_{{ key }}_authn_failed%"
                 pop_failed: "%gssp_{{ key }}_pop_failed%"
                 app_android_url: "%gssp_{{ key }}_app_android_url%"


### PR DESCRIPTION
Previously the initiate title was used instead of the explanation

Also see:
https://github.com/OpenConext/Stepup-SelfService/pull/206
https://www.pivotaltracker.com/story/show/174858638