### PR TITLE
Improve accuracy of case-C test

### DIFF
--- a/tests/behat/features/fga-use-case-c.feature
+++ b/tests/behat/features/fga-use-case-c.feature
@@ -23,7 +23,7 @@ Feature: Use case C: Closely cooperating institutions
                     "institution-d.example.com"
                 ],
                 "use_raa": [
-                    "institution-d.example.com"
+                    "institution-a.example.com"
                 ]
             },
             "institution-d.example.com": {
@@ -37,7 +37,7 @@ Feature: Use case C: Closely cooperating institutions
                     "institution-d.example.com"
                 ],
                 "use_raa": [
-                    "institution-a.example.com"
+                    "institution-d.example.com"
                 ]
             }
         }


### PR DESCRIPTION
Previously the select raa functionality was tested, piggy backing on the use-raa feature. That was a bug fixed in Middleware.

See: https://www.pivotaltracker.com/story/show/175056146 for a full bug report and more backgrounds
See: https://github.com/OpenConext/Stepup-Middleware/pull/315 use this branch to run the behat tests

All other components should run on the latest `develop`