### PR TITLE
Add PHP Zip extension

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -301,14 +301,6 @@
     - /app/config/samlstepupproviders_parameters.yml
     ignore_errors: True
 
-  # TODO: Fix this
-  # There is no zip extension in the REMI php72 repo from centos7
-  # Disable platform requirements checking to work around this
-  - name: Stepup-Azure-MFA ext-zip requirement fix
-    set_fact:
-      deploy_ignore_platform_reqs: "--ignore-platform-reqs"
-    when: component_name == "azuremfa"
-
   # The {{ set_nvm_nodejs_version_cmd }} is added for Tiqr versions that run encore during composer install
   - name: DEVELOP - Composer install
     shell: "{{ set_nvm_nodejs_version_cmd }} && export COMPOSER_CACHE_DIR=/vagrant/composer_cache && {{ php_cli }} /usr/local/bin/composer install --no-interaction --working-dir={{ component_dir_name }} {{ deploy_ignore_platform_reqs }}"

--- a/roles/dev/tasks/main.yml
+++ b/roles/dev/tasks/main.yml
@@ -27,6 +27,8 @@
       # xdebug, the PHP debug extension
       - php-pecl-xdebug
       - php72-php-pecl-xdebug
+
+      - php72-php-pecl-zip
       # telnet client
       - telnet
     state: present


### PR DESCRIPTION
Webdriver requires zip extension. This will install the
php zip extension RPM.