### PR TITLE
Update gssp config without install

### DIFF
--- a/roles/deploy/tasks/activate.yml
+++ b/roles/deploy/tasks/activate.yml
@@ -17,3 +17,4 @@
 
 - name: Activate component
   file: src={{ component_dir_name }} dest=/opt/www/{{ component_vhost_name }} state=link
+  when: not component_info.failed

--- a/roles/deploy/tasks/activate.yml
+++ b/roles/deploy/tasks/activate.yml
@@ -17,4 +17,4 @@
 
 - name: Activate component
   file: src={{ component_dir_name }} dest=/opt/www/{{ component_vhost_name }} state=link
-  when: not component_info.failed
+  when: not configonly | bool

--- a/roles/deploy/tasks/deploy.yml
+++ b/roles/deploy/tasks/deploy.yml
@@ -13,19 +13,21 @@
   command: "{{ php_cli }} {{ console }} assets:install --symlink --env=prod {{ debug_flag }}"
   args:
     chdir: "{{ component_dir_name }}"
+  when: not configonly | bool
+
 
 - name: Run mopa:bootstrap:symlink:less for SF3 gateway, selfservice, ra and tiqr
   command: "{{ php_cli }} {{ console }} mopa:bootstrap:symlink:less --env=prod {{ debug_flag }}"
   args:
       chdir: "{{ component_dir_name }}"
   # Make conditional on deploy_assetic as well?
-  when: deploy_symfony_3 and component_name in ['gateway', 'selfservice', 'ra']
+  when: deploy_symfony_3 and component_name in ['gateway', 'selfservice', 'ra'] and not configonly | bool
 
 - name: Dump Assetic Assets
   command: "{{ php_cli }} {{ console }} assetic:dump --env=prod {{ debug_flag }}"
   args:
     chdir: "{{ component_dir_name }}"
-  when: deploy_assetic
+  when: deploy_assetic and not configonly | bool
 
 - name: Clear and warmup cache
   command: "{{ php_cli }} {{ console }} cache:clear --env=prod {{ debug_flag }}"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -83,21 +83,25 @@
     group:
       name: "{{ component_name }}"
       state: present
+    when: not configonly | bool
 
   - name: Ensure user exists
     user:
       name: "{{ component_name }}"
       state: present
+    when: not configonly | bool
 
   - name: Create stepup directory
     file: path={{ component_dir_name }} state=directory group={{ component_name }} mode=755
+    when: not configonly | bool
 
   - name: Untar component
     unarchive: copy=yes src={{ component_tarball_name }} dest={{ component_dir_name }} group={{ component_name }}
-    when: component_unarchive | bool | default(true)
+    when: component_unarchive | bool | default(true) and not configonly | bool
 
   - name: Remove group and world write
     file: dest={{ component_dir_name }} group={{ component_name }} recurse=yes mode="g-w,o-w"
+    when: not configonly | bool
 
   - name: Set debug, mode, owner and group for production
     set_fact:
@@ -219,7 +223,7 @@
   with_items:
   - parameters
   - institutions
-  when: component_name == "azuremfa"
+  when: component_name == "azuremfa" and not configonly | bool
 
 - block:
 # DEVELOP
@@ -241,13 +245,13 @@
 
   # The dev role installed nvm (node version manager) for nodejs
   # Read the NODE_VERSION form component_info (if any)
-  - name: Fetch nodejs version from component_info
+  - name: DEVELOP - Fetch nodejs version from component_info
     set_fact:
       component_info_node_version: "{{ component_info.content | b64decode | regex_search('NODE_VERSION=(.*)', '\\1' ) }}"
       component_info_encore: "{{ component_info.content | b64decode | regex_search('ENCORE=(.*)', '\\1' ) }}"
     when: not component_info.failed
 
-  - name: Set nodejs version from component_info
+  - name: DEVELOP - Set nodejs version from component_info
     set_fact:
       deploy_node_version: "{{ (component_info_node_version | length > 0) | ternary(component_info_node_version[0], deploy_node_version) }}"
       deploy_encore: "{{ (component_info_encore | length > 0) | ternary(component_info_encore[0], deploy_encore) }}"
@@ -255,11 +259,11 @@
 
   # A nodejs version other than 10 is only used for running encore. Encore is needed during develop deploy
   # from source only.
-  - name: Nodejs version and encore
+  - name: DEVELOP - Nodejs version and encore
     debug:
       msg: "deploy_node_version={{ deploy_node_version }}; deploy_encore={{ deploy_encore }}"
 
-  - name: Set NVM command
+  - name: DEVELOP - Set NVM command
     set_fact:
       set_nvm_nodejs_version_cmd: "source /root/.nvm/nvm.sh && nvm use {{ deploy_node_version }}"
 
@@ -289,7 +293,7 @@
   # - find a way to provide defaults for composer install
   #
   # For now: always copy parameters.yml.dist to parameter.yml in dev mode
-  - name: Copy dist files
+  - name: DEVELOP - Copy dist files
     copy:
       src: "{{ component_dir_name }}{{ item }}.dist"
       dest: "{{ component_dir_name }}{{ item }}"
@@ -305,25 +309,25 @@
   # TODO: Fix this
   # There is no zip extension in the REMI php72 repo from centos7
   # Disable platform requirements checking to work around this
-  - name: Stepup-Azure-MFA ext-zip requirement fix
+  - name: DEVELOP - Stepup-Azure-MFA ext-zip requirement fix
     set_fact:
       deploy_ignore_platform_reqs: "--ignore-platform-reqs"
     when: component_name == "azuremfa"
 
   # The {{ set_nvm_nodejs_version_cmd }} is added for Tiqr versions that run encore during composer install
-  - name: DEVELOP - Composer install
+  - name: DEVELOP -  Composer install
     shell: "{{ set_nvm_nodejs_version_cmd }} && export COMPOSER_CACHE_DIR=/vagrant/composer_cache && {{ php_cli }} /usr/local/bin/composer install --no-interaction --working-dir={{ component_dir_name }} {{ deploy_ignore_platform_reqs }}"
 
   # Run "yarn install && yarn encore dev" for those components that require it
   # Note: this takes a long time
-  - name: DEVELOP - Run yarn install and yarn encore dev
+  - name: DEVELOP -  Run yarn install and yarn encore dev
     shell: "{{ set_nvm_nodejs_version_cmd }} && yarn install && yarn encore dev"
     args:
       chdir: "{{ component_dir_name }}"
     when: deploy_encore
 
   # Rebuild cache
-  - name: DEVELOP - Clear cache (/app/console)
+  - name: DEVELOP -  Clear cache (/app/console)
     shell: "{{ php_cli }} {{ component_dir_name }}/{{ console }} cache:clear --env=prod --no-warmup"
 
   # In a develop deploy the components are installed from source in the Stepup-VM. The sources are
@@ -357,7 +361,7 @@
     copy: remote_src=true src={{ component_dir_name }}/app_test.php.dist dest={{ component_dir_name }}/web/app_test.php
     when: deploy_symfony_3 and component_name not in ["tiqr", "keyserver"]
 
-  when: develop | default(false)
+  when: develop | default(false) and not configonly | bool
 
 
 - name: Ensure component config direcories exist

--- a/roles/stepup-webauthn/tasks/main.yml
+++ b/roles/stepup-webauthn/tasks/main.yml
@@ -55,9 +55,9 @@
   template: src={{ item }}.j2 dest=/root/{{ item }} group=root owner=root mode="500"
   with_items:
   - "01-webauthn-db_init.sh"
-  when: not component_info.failed
+  when: not configonly | bool
 
 - name: Show database configuration hint
   debug:
     msg: "Note: Database initialisation/migration must be run manually once. Run '/root/01-webauthn-db_init.sh' on an app server."
-  when: not component_info.failed
+  when: not configonly | bool

--- a/roles/stepup-webauthn/tasks/main.yml
+++ b/roles/stepup-webauthn/tasks/main.yml
@@ -55,7 +55,9 @@
   template: src={{ item }}.j2 dest=/root/{{ item }} group=root owner=root mode="500"
   with_items:
   - "01-webauthn-db_init.sh"
+  when: not component_info.failed
 
 - name: Show database configuration hint
   debug:
     msg: "Note: Database initialisation/migration must be run manually once. Run '/root/01-webauthn-db_init.sh' on an app server."
+  when: not component_info.failed

--- a/roles/stepup-webauthn/tasks/main.yml
+++ b/roles/stepup-webauthn/tasks/main.yml
@@ -28,6 +28,7 @@
     state: directory
     group: "{{ component_group }}"
     mode: "{{ component_mode_755 }}"
+  when: not configonly | bool
 
 - name: Copy trusted certificates
   copy: src={{ item }} dest={{ component_config_file_dir_name }}/trusted_certificates/ mode={{ component_mode_444 }} group={{ component_group }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,7 @@
 CWD=`pwd`
 BASEDIR=`dirname $0`
 COMPONENTS=("Stepup-Middleware" "Stepup-Gateway" "Stepup-SelfService" "Stepup-RA" "Stepup-tiqr" "Stepup-Webauthn" "oath-service-php" "Stepup-Azure-MFA")
+CONFIG_ONLY_COMPONENTS=("Stepup-Webauthn" "Stepup-Azure-MFA")
 UNARCHIVE=1
 CONFIGONLY=0
 VERBOSE=0
@@ -49,7 +50,7 @@ if [ -z "${COMPONENT_TARBALL}"  ]; then
     echo "-l|--limit: <SUBSET>   Limit option to pass to ansible (limits hosts)"
     echo "-K|--ask-sudo-pass     Ask for sudo password"
     echo "-n|--no-unarchive      Skip uploading and unarchiving the tarball on the remote"
-    echo "-c|--config-only       Only update the components configuration files (only for AzureMFA-gssp and WebAuthn-gssp)"
+    echo "-c|--config-only       Only update the components configuration files (only for: ${CONFIG_ONLY_COMPONENTS[*]})"
     echo "-v|--verbose           Pass \"-vvvv\" verbosity to ansible"
     echo "Supported components: ${COMPONENTS[*]}"
     exit 1;
@@ -113,6 +114,13 @@ for comp in "${COMPONENTS[@]}"; do
 done
 if [ "$found" -ne "1" ]; then
     error_exit "Tarball to deploy must end in .tar.bz2 and start with one of: ${COMPONENTS[*]}"
+fi
+
+#If -c is set, and componet does not support -c, error here
+if [ ${CONFIGONLY} -eq "1" ]; then
+  if [[ ! "${CONFIG_ONLY_COMPONENTS[@]}" =~ "${COMPONENT}" ]]; then
+    error_exit "${COMPONENT} does not support -c|--config-only"
+  fi
 fi
 
 # Get absolute path to component tarball


### PR DESCRIPTION
Add a new option to the deploy-scipt ```-c|--config-only```. This wil cause only the components configuration to be updated, without any intrusive actions (like extracting tar's, copying default files, creating/updating users). This way an updated configuration (e.g. new AzureMFA institutions.yml, or WebAuthn trusted certificates) van be send to app-servers, without interrupting users.