### PR TITLE
Make Behat tests Symfony 4 proof

### DIFF
--- a/roles/app/templates/php72-nginx-vhost-symfony4.conf.j2
+++ b/roles/app/templates/php72-nginx-vhost-symfony4.conf.j2
@@ -42,8 +42,24 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param HTTPS on;
-        fastcgi_param SYMFONY_ENV prod;
-        fastcgi_param APP_ENV prod;
+
+        {% if 'dev' not in group_names %}
+        # Non dev environments have the symfony env set to prod in a hardcoded manner
+        set $app_env "prod";
+        set $app_debug false;
+        {% elif 'dev' in group_names %}
+        # If the testcookie is present, we will kick the symfony environment into smoketest mode. Otherwise dev mode it is.
+        set $app_env "dev";
+        set $app_debug true;
+        if ($cookie_testcookie) {
+            set $app_env "smoketest";
+            set $app_debug true;
+        }
+        {% endif %}
+
+        fastcgi_param SYMFONY_ENV $app_env;
+        fastcgi_param APP_ENV $app_env;
+        fastcgi_param APP_DEBUG $app_debug;
     }
 
     {# Finally, disallow opening php files outside of index.php #}

--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -51,16 +51,16 @@ class FeatureContext implements Context
     {
         // Generate test databases
         echo "Preparing test schemas\n";
-        shell_exec("/src/Stepup-Middleware/app/console doctrine:schema:drop --env=smoketest --force");
-        shell_exec("/src/Stepup-Gateway/app/console doctrine:schema:drop --env=test --force");
-        shell_exec("/src/Stepup-Middleware/app/console doctrine:schema:create --env=smoketest");
-        shell_exec("/src/Stepup-Gateway/app/console doctrine:schema:create --env=test");
+        shell_exec("php72 /src/Stepup-Middleware/bin/console doctrine:schema:drop --env=smoketest --force");
+        shell_exec("php72 /src/Stepup-Gateway/bin/console doctrine:schema:drop --env=test --force");
+        shell_exec("php72 /src/Stepup-Middleware/bin/console doctrine:schema:create --env=smoketest");
+        shell_exec("php72 /src/Stepup-Gateway/bin/console doctrine:schema:create --env=test");
 
         echo "Replaying event stream\n";
         // Import the events.sql into middleware
         shell_exec("mysql -uroot -ppassword middleware_test < ./fixtures/events.sql");
         // Perform an event replay
-        shell_exec("/src/Stepup-Middleware/app/console middleware:event:replay --env=smoketest_event_replay --no-interaction -q");
+        shell_exec("php72 /src/Stepup-Middleware/bin/console middleware:event:replay --env=smoketest_event_replay --no-interaction -q");
 
         echo "Update the keys\n";
         // Update the `saml_entities` projection in `gateway_test`


### PR DESCRIPTION
Some changes are required to get the Behat tests to work again

1. The SF4 Nginx config is updated to enable smoke tests to run
2. The behat contexts need to call console actions on `bin/console`, not `app/console`