### PR TITLE
PHP-FPM configs: Enable the status page

### DIFF
--- a/roles/app/templates/php56-fpm-pool.conf.j2
+++ b/roles/app/templates/php56-fpm-pool.conf.j2
@@ -118,7 +118,7 @@ pm.max_spare_servers = 10
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set
-;pm.status_path = /status
+pm.status_path = /status
 
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside

--- a/roles/app/templates/php72-fpm-pool.conf.j2
+++ b/roles/app/templates/php72-fpm-pool.conf.j2
@@ -119,7 +119,7 @@ pm.max_spare_servers = 10
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set
-;pm.status_path = /status
+pm.status_path = /status
 
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside


### PR DESCRIPTION
This will allow monitoring agents to access the php fpm statistics over the php-fpm status socket