### PR TITLE
Add event data integrity test

### DIFF
--- a/tests/behat/features/event_verification.feature
+++ b/tests/behat/features/event_verification.feature
@@ -1,0 +1,23 @@
+Feature: The application managers are concerned with correct data ending up in the event stream
+  In order to ensure no sensitive data ends up in the event stream
+  As an administrator
+  I must check the payload of the events for presence of sensitive data
+
+  Scenario: Provision an institution and a user to promote later on by an authorized institution
+    Given institution "institution-a.example.com" can "use_ra" from institution "institution-a.example.com"
+    And institution "institution-a.example.com" can "select_raa" from institution "institution-a.example.com"
+    And institution "institution-d.example.com" can "use_ra" from institution "institution-a.example.com"
+    And a user "Jane Toppan" identified by "urn:collab:person:institution-a.example.com:jane-a-ra" from institution "institution-a.example.com"
+    And the user "urn:collab:person:institution-a.example.com:jane-a-ra" has a vetted "yubikey"
+    And the user "urn:collab:person:institution-a.example.com:jane-a-ra" has the role "ra" for institution "institution-a.example.com"
+
+  Scenario: RA user can vet a token from an institution it is RA for
+    Given I am logged in into the selfservice portal as "joe-a1"
+    And I register a new SMS token
+    And I verify my e-mail address
+    When I am logged in into the ra portal as "jane-a-ra" with a "yubikey" token
+    And I vet the last added second factor
+   Then the resulting "SecondFactorVetted" event should not contain "common_name"
+   And the resulting "SecondFactorVetted" event should not contain "vetting_type"
+   And the resulting "SecondFactorVetted" event should not contain "document_number"
+   And the resulting "SecondFactorVetted" event should contain "name_id"

--- a/tests/behat/features/src/Repository/EventStreamRepository.php
+++ b/tests/behat/features/src/Repository/EventStreamRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Surfnet\StepupBehat\Repository;
+
+use PDO;
+
+/**
+ * A poor mans repository, a pdo connection to the test database is established in the constructor
+ */
+class EventStreamRepository
+{
+    /**
+     * @var PDO
+     */
+    private $connection;
+
+    public function __construct()
+    {
+        // Settings
+        $dbUser = 'root';
+        $dbPassword = 'password';
+        $dbName = 'middleware_test';
+        $dsn = 'mysql:host=127.0.0.1;dbname=%s';
+        // Open a PDO connection
+        $this->connection = new PDO(sprintf($dsn, $dbName), $dbUser, $dbPassword);
+    }
+
+    public function findLatestByEventName(string $name): array
+    {
+        $sql = 'SELECT * FROM `event_stream` WHERE type LIKE CONCAT("%", :name) ORDER BY recorded_on DESC LIMIT 1';
+        $statement = $this->connection->exec($sql);
+        $statement->execute(['name' => $name]);
+        return $statement->fetch();
+    }
+}


### PR DESCRIPTION
The Middleware command handler tests the correct data on an Event, this however is the deserialized data that is constructed on the event. The event payload may contain additional data which in turn could be sensitive data.

This behat test is created to test the presence of certain data on the event.