### PR TITLE
DB role: Allow provisioning of users from a deployhost

### DIFF
--- a/roles/db/defaults/main.yml
+++ b/roles/db/defaults/main.yml
@@ -4,3 +4,5 @@
 # It is suggested you specify the node to bootstrap when running the playbook. E.g.:
 # ansible-playbook ... -e "galera_bootstrap_node=<hostname of the node to bootstrap>"
 galera_bootstrap_node: ""
+galera_privision_host: 127.0.0.1
+galera_root_user: root

--- a/roles/db/tasks/gateway.yml
+++ b/roles/db/tasks/gateway.yml
@@ -1,7 +1,12 @@
 # Database configuration for gateway component
 
 - name: Create Gateway database
-  mysql_db: name={{ database_gateway_name }} state=present login_user=root login_password={{ mariadb_root_password | vault(vault_keydir) }}
+  mysql_db: 
+    name: "{{ database_gateway_name }}" 
+    state: "present" 
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
+    login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 - name: Create gateway user
   mysql_user:
@@ -9,7 +14,8 @@
     host: "%"
     password: "{{ database_gateway_password | vault(vault_keydir) }}"
     priv: "{{ database_gateway_name }}.*:SELECT"
-    login_user: root
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 - name: Create gateway read-only user
@@ -18,7 +24,7 @@
     host: "%"
     password: "{{ database_gateway_readonly_password | vault(vault_keydir) }}"
     priv: "{{ database_gateway_name }}.*:SELECT"
-    login_host: "127.0.0.1"
-    login_user: "root"
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
   when: database_gateway_readonly_user is defined

--- a/roles/db/tasks/keyserver.yml
+++ b/roles/db/tasks/keyserver.yml
@@ -1,7 +1,12 @@
 # Database configuration for keyserver component
 
 - name: Create keyserver database
-  mysql_db: name={{ database_keyserver_name }} state=present login_user=root login_password={{ mariadb_root_password | vault(vault_keydir) }}
+  mysql_db: 
+    name: "{{ database_keyserver_name }}" 
+    state: "present" 
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}" 
+    login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 - name: Create keyserver deploy DB user with ALL access to keyserver database
   mysql_user:
@@ -9,8 +14,8 @@
     host: "%"
     password: "{{ database_keyserver_deploy_password | vault(vault_keydir) }}"
     priv: "{{ database_keyserver_name }}.*:ALL\ PRIVILEGES,GRANT"
-    login_host: "127.0.0.1"
-    login_user: "root"
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 
@@ -20,7 +25,6 @@
     host: "%"
     password: "{{ database_keyserver_password | vault(vault_keydir) }}"
     priv: "{{ database_keyserver_name }}.*:SELECT,INSERT,DELETE,UPDATE"
-    login_host: "127.0.0.1"
-    login_user: root
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
-

--- a/roles/db/tasks/main.yml
+++ b/roles/db/tasks/main.yml
@@ -117,7 +117,12 @@
 
 
 - include: middleware.yml
+  tags: mariadb_create_db_and_users
 - include: gateway.yml
+  tags: mariadb_create_db_and_users
 - include: tiqr.yml
+  tags: mariadb_create_db_and_users
 - include: keyserver.yml
+  tags: mariadb_create_db_and_users
 - include: webauthn.yml
+  tags: mariadb_create_db_and_users

--- a/roles/db/tasks/middleware.yml
+++ b/roles/db/tasks/middleware.yml
@@ -1,11 +1,21 @@
 # Database configuration for middleware component
 
 - name: Create Middleware database
-  mysql_db: name={{ database_middleware_name }} state=present login_user=root login_password={{ mariadb_root_password | vault(vault_keydir) }}
+  mysql_db: 
+    name: "{{ database_middleware_name }}" 
+    state: "present" 
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
+    login_password=: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 # Both midleware and gateway databases are managed using middleware app/console (for now)
 - name: Create Gateway database
-  mysql_db: name={{ database_gateway_name }} state=present login_user=root login_password={{ mariadb_root_password | vault(vault_keydir) }}
+  mysql_db: 
+    name: "{{ database_gateway_name }}" 
+    state: "present" 
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
+    login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 
 - name: Create middleware deploy user with ALL access to middleware and gateway database
@@ -14,8 +24,8 @@
     host: "%"
     password: "{{ database_middleware_deploy_password | vault(vault_keydir) }}"
     priv: "{{ database_gateway_name }}.*:ALL\ PRIVILEGES,GRANT/{{ database_middleware_name }}.*:ALL\ PRIVILEGES,GRANT"
-    login_host: "127.0.0.1"
-    login_user: "root"
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 
@@ -27,8 +37,8 @@
     host: "%"
     password: "{{ database_middleware_password | vault(vault_keydir) }}"
     priv: "{{ database_middleware_name }}.*:SELECT,INSERT,DELETE,UPDATE/{{ database_gateway_name }}.*:SELECT,INSERT,DELETE,UPDATE"
-    login_host: "127.0.0.1"
-    login_user: "root"
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 - name: Create middleware read-only user
@@ -37,7 +47,7 @@
     host: "%"
     password: "{{ database_middleware_readonly_password | vault(vault_keydir) }}"
     priv: "{{ database_middleware_name }}.*:SELECT"
-    login_host: "127.0.0.1"
-    login_user: "root"
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
   when: database_middleware_readonly_user is defined

--- a/roles/db/tasks/tiqr.yml
+++ b/roles/db/tasks/tiqr.yml
@@ -1,6 +1,10 @@
 - name: Create tiqr database
-  mysql_db: name={{ database_tiqr_name }} state=present login_user=root login_password={{ mariadb_root_password | vault(vault_keydir) }}
-
+  mysql_db: 
+    name: "{{ database_tiqr_name }}" 
+    state: "present" 
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
+    login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 - name: Create tiqr deploy DB user with ALL access to tiqr database
   mysql_user:
@@ -8,8 +12,8 @@
     host: "%"
     password: "{{ database_tiqr_deploy_password | vault(vault_keydir) }}"
     priv: "{{ database_tiqr_name }}.*:ALL\ PRIVILEGES,GRANT"
-    login_host: "127.0.0.1"
-    login_user: "root"
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 
@@ -19,6 +23,6 @@
     host: "%"
     password: "{{ database_tiqr_password | vault(vault_keydir) }}"
     priv: "{{ database_tiqr_name }}.*:SELECT,INSERT,DELETE,UPDATE"
-    login_host: "127.0.0.1"
-    login_user: root
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"

--- a/roles/db/tasks/webauthn.yml
+++ b/roles/db/tasks/webauthn.yml
@@ -1,7 +1,11 @@
 # Database configuration for webauthn component
 
 - name: Create webauthn database
-  mysql_db: name={{ database_webauthn_name }} state=present login_user=root login_password={{ mariadb_root_password | vault(vault_keydir) }}
+  mysql_db: name: "{{ database_webauthn_name }}" 
+    state: "present" 
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
+    login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 - name: Create webauthn deploy user with ALL access to webauthn database
   mysql_user:
@@ -9,8 +13,8 @@
     host: "%"
     password: "{{ database_webauthn_deploy_password | vault(vault_keydir) }}"
     priv: "{{ database_webauthn_name }}.*:ALL\ PRIVILEGES,GRANT"
-    login_host: "127.0.0.1"
-    login_user: "root"
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"
 
 - name: Create DB user for webauthn component
@@ -19,6 +23,6 @@
     host: "%"
     password: "{{ database_webauthn_password | vault(vault_keydir) }}"
     priv: "{{ database_webauthn_name }}.*:SELECT,INSERT,DELETE,UPDATE"
-    login_host: "127.0.0.1"
-    login_user: root
+    login_host: "{{ mariadb_provision_host }}"
+    login_user: "{{ mariadb_root_user }}"
     login_password: "{{ mariadb_root_password | vault(vault_keydir) }}"


### PR DESCRIPTION
This change allows you to provision databases, users and passwords from
a deployment host (where the mysqlconnection is from the provisioning
host to the database host). You will need an inventory like this to make this work:
```
[dbcluster]
localhost ansible_connection=local mariadb_provision_host=your.remote.mysql.host
```